### PR TITLE
nvmf: Add context parameter to new_qpair()

### DIFF
--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -169,7 +169,7 @@ void spdk_nvmf_tgt_listen(struct spdk_nvmf_tgt *tgt,
  *
  * \param qpair The newly discovered qpair.
  */
-typedef void (*new_qpair_fn)(struct spdk_nvmf_qpair *qpair);
+typedef void (*new_qpair_fn)(struct spdk_nvmf_qpair *qpair, void *cb_arg);
 
 /**
  * Poll the target for incoming connections.
@@ -181,7 +181,7 @@ typedef void (*new_qpair_fn)(struct spdk_nvmf_qpair *qpair);
  * \param tgt The target associated with the listen address.
  * \param cb_fn Called for each newly discovered qpair.
  */
-void spdk_nvmf_tgt_accept(struct spdk_nvmf_tgt *tgt, new_qpair_fn cb_fn);
+void spdk_nvmf_tgt_accept(struct spdk_nvmf_tgt *tgt, new_qpair_fn cb_fn, void *cb_arg);
 
 /**
  * Create a poll group.

--- a/lib/event/subsystems/nvmf/nvmf_tgt.c
+++ b/lib/event/subsystems/nvmf/nvmf_tgt.c
@@ -250,7 +250,7 @@ nvmf_tgt_poll_group_add(void *_ctx)
 }
 
 static void
-new_qpair(struct spdk_nvmf_qpair *qpair)
+new_qpair(struct spdk_nvmf_qpair *qpair, void *cb_arg)
 {
 	struct nvmf_tgt_pg_ctx *ctx;
 	struct nvmf_tgt_poll_group *pg;
@@ -294,7 +294,7 @@ acceptor_poll(void *arg)
 {
 	struct spdk_nvmf_tgt *tgt = arg;
 
-	spdk_nvmf_tgt_accept(tgt, new_qpair);
+	spdk_nvmf_tgt_accept(tgt, new_qpair, NULL);
 
 	return -1;
 }

--- a/lib/nvmf/fc.c
+++ b/lib/nvmf/fc.c
@@ -1971,7 +1971,7 @@ nvmf_fc_stop_listen(struct spdk_nvmf_transport *transport,
 }
 
 static void
-nvmf_fc_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn)
+nvmf_fc_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn, void *cb_arg)
 {
 	struct spdk_nvmf_fc_port *fc_port = NULL;
 	static bool start_lld = false;

--- a/lib/nvmf/fc_ls.c
+++ b/lib/nvmf/fc_ls.c
@@ -596,7 +596,7 @@ nvmf_fc_ls_add_conn_to_poller(
 
 	/* Let the nvmf_tgt decide which pollgroup to use. */
 	fc_conn->create_opd = opd;
-	fc_port->new_qp_cb(&fc_conn->qpair);
+	fc_port->new_qp_cb(&fc_conn->qpair, fc_port->new_qp_arg);
 }
 
 /* Delete association functions */

--- a/lib/nvmf/nvmf.c
+++ b/lib/nvmf/nvmf.c
@@ -617,12 +617,12 @@ spdk_nvmf_tgt_get_transport(struct spdk_nvmf_tgt *tgt, enum spdk_nvme_transport_
 }
 
 void
-spdk_nvmf_tgt_accept(struct spdk_nvmf_tgt *tgt, new_qpair_fn cb_fn)
+spdk_nvmf_tgt_accept(struct spdk_nvmf_tgt *tgt, new_qpair_fn cb_fn, void *cb_arg)
 {
 	struct spdk_nvmf_transport *transport, *tmp;
 
 	TAILQ_FOREACH_SAFE(transport, &tgt->transports, link, tmp) {
-		spdk_nvmf_transport_accept(transport, cb_fn);
+		spdk_nvmf_transport_accept(transport, cb_fn, cb_arg);
 	}
 }
 

--- a/lib/nvmf/nvmf_fc.h
+++ b/lib/nvmf/nvmf_fc.h
@@ -316,6 +316,7 @@ struct spdk_nvmf_fc_port {
 	uint16_t fcp_rq_id;
 	struct spdk_nvmf_fc_hwqp ls_queue;
 	new_qpair_fn new_qp_cb;
+	void *new_qp_arg;
 
 	uint32_t num_io_queues;
 	struct spdk_nvmf_fc_hwqp *io_queues;

--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -1228,7 +1228,7 @@ spdk_nvmf_rdma_event_reject(struct rdma_cm_id *id, enum spdk_nvmf_rdma_transport
 
 static int
 nvmf_rdma_connect(struct spdk_nvmf_transport *transport, struct rdma_cm_event *event,
-		  new_qpair_fn cb_fn)
+		  new_qpair_fn cb_fn, void *cb_arg)
 {
 	struct spdk_nvmf_rdma_transport *rtransport;
 	struct spdk_nvmf_rdma_qpair	*rqpair = NULL;
@@ -1321,7 +1321,7 @@ nvmf_rdma_connect(struct spdk_nvmf_transport *transport, struct rdma_cm_event *e
 
 	event->id->context = &rqpair->qpair;
 
-	cb_fn(&rqpair->qpair);
+	cb_fn(&rqpair->qpair, cb_arg);
 
 	return 0;
 }
@@ -2767,7 +2767,7 @@ nvmf_rdma_handle_last_wqe_reached(void *ctx)
 }
 
 static void
-spdk_nvmf_process_cm_event(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn)
+spdk_nvmf_process_cm_event(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn, void *cb_arg)
 {
 	struct spdk_nvmf_rdma_transport *rtransport;
 	struct rdma_cm_event		*event;
@@ -2794,7 +2794,7 @@ spdk_nvmf_process_cm_event(struct spdk_nvmf_transport *transport, new_qpair_fn c
 				/* No action required. The target never attempts to resolve routes. */
 				break;
 			case RDMA_CM_EVENT_CONNECT_REQUEST:
-				rc = nvmf_rdma_connect(transport, event, cb_fn);
+				rc = nvmf_rdma_connect(transport, event, cb_fn, cb_arg);
 				if (rc < 0) {
 					SPDK_ERRLOG("Unable to process connect event. rc: %d\n", rc);
 					break;
@@ -2932,7 +2932,7 @@ spdk_nvmf_process_ib_event(struct spdk_nvmf_rdma_device *device)
 }
 
 static void
-spdk_nvmf_rdma_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn)
+spdk_nvmf_rdma_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn, void *cb_arg)
 {
 	int	nfds, i = 0;
 	struct spdk_nvmf_rdma_transport *rtransport;
@@ -2947,7 +2947,7 @@ spdk_nvmf_rdma_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn)
 
 	/* The first poll descriptor is RDMA CM event */
 	if (rtransport->poll_fds[i++].revents & POLLIN) {
-		spdk_nvmf_process_cm_event(transport, cb_fn);
+		spdk_nvmf_process_cm_event(transport, cb_fn, cb_arg);
 		nfds--;
 	}
 

--- a/lib/nvmf/tcp.c
+++ b/lib/nvmf/tcp.c
@@ -1092,7 +1092,8 @@ spdk_nvmf_tcp_qpair_sock_init(struct spdk_nvmf_tcp_qpair *tqpair)
 static void
 _spdk_nvmf_tcp_handle_connect(struct spdk_nvmf_transport *transport,
 			      struct spdk_nvmf_tcp_port *port,
-			      struct spdk_sock *sock, new_qpair_fn cb_fn)
+			      struct spdk_sock *sock,
+			      new_qpair_fn cb_fn, void *cb_arg)
 {
 	struct spdk_nvmf_tcp_qpair *tqpair;
 	int rc;
@@ -1133,12 +1134,12 @@ _spdk_nvmf_tcp_handle_connect(struct spdk_nvmf_transport *transport,
 		return;
 	}
 
-	cb_fn(&tqpair->qpair);
+	cb_fn(&tqpair->qpair, cb_arg);
 }
 
 static void
 spdk_nvmf_tcp_port_accept(struct spdk_nvmf_transport *transport, struct spdk_nvmf_tcp_port *port,
-			  new_qpair_fn cb_fn)
+			  new_qpair_fn cb_fn, void *cb_arg)
 {
 	struct spdk_sock *sock;
 	int i;
@@ -1146,13 +1147,13 @@ spdk_nvmf_tcp_port_accept(struct spdk_nvmf_transport *transport, struct spdk_nvm
 	for (i = 0; i < NVMF_TCP_MAX_ACCEPT_SOCK_ONE_TIME; i++) {
 		sock = spdk_sock_accept(port->listen_sock);
 		if (sock) {
-			_spdk_nvmf_tcp_handle_connect(transport, port, sock, cb_fn);
+			_spdk_nvmf_tcp_handle_connect(transport, port, sock, cb_fn, cb_arg);
 		}
 	}
 }
 
 static void
-spdk_nvmf_tcp_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn)
+spdk_nvmf_tcp_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn, void *cb_arg)
 {
 	struct spdk_nvmf_tcp_transport *ttransport;
 	struct spdk_nvmf_tcp_port *port;
@@ -1160,7 +1161,7 @@ spdk_nvmf_tcp_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn)
 	ttransport = SPDK_CONTAINEROF(transport, struct spdk_nvmf_tcp_transport, transport);
 
 	TAILQ_FOREACH(port, &ttransport->ports, link) {
-		spdk_nvmf_tcp_port_accept(transport, port, cb_fn);
+		spdk_nvmf_tcp_port_accept(transport, port, cb_fn, cb_arg);
 	}
 }
 

--- a/lib/nvmf/transport.c
+++ b/lib/nvmf/transport.c
@@ -171,9 +171,9 @@ spdk_nvmf_transport_stop_listen(struct spdk_nvmf_transport *transport,
 }
 
 void
-spdk_nvmf_transport_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn)
+spdk_nvmf_transport_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn, void *cb_arg)
 {
-	transport->ops->accept(transport, cb_fn);
+	transport->ops->accept(transport, cb_fn, cb_arg);
 }
 
 void

--- a/lib/nvmf/transport.h
+++ b/lib/nvmf/transport.h
@@ -87,7 +87,7 @@ struct spdk_nvmf_transport_ops {
 	/**
 	 * Check for new connections on the transport.
 	 */
-	void (*accept)(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn);
+	void (*accept)(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn, void *cb_arg);
 
 	/**
 	 * Fill out a discovery log entry for a specific listen address.
@@ -183,7 +183,8 @@ struct spdk_nvmf_transport_ops {
 int spdk_nvmf_transport_stop_listen(struct spdk_nvmf_transport *transport,
 				    const struct spdk_nvme_transport_id *trid);
 
-void spdk_nvmf_transport_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn);
+void spdk_nvmf_transport_accept(struct spdk_nvmf_transport *transport, new_qpair_fn cb_fn,
+				void *cb_arg);
 
 void spdk_nvmf_transport_listener_discover(struct spdk_nvmf_transport *transport,
 		struct spdk_nvme_transport_id *trid,


### PR DESCRIPTION
It can be useful for passing additional information about nvmf
target to a handler for new nvmf connections. Avoiding costly
lookup of this information from globals (that applies even more
to rust).