### PR TITLE
Use getpid instead of id from g_spdk_app struct for iscsi conns

### DIFF
--- a/lib/iscsi/conn.c
+++ b/lib/iscsi/conn.c
@@ -139,7 +139,12 @@ int initialize_iscsi_conns(void)
 
 	SPDK_DEBUGLOG(SPDK_LOG_ISCSI, "spdk_iscsi_init\n");
 
-	snprintf(g_shm_name, sizeof(g_shm_name), "/spdk_iscsi_conns.%d", spdk_app_get_shm_id());
+	/*
+	 * Mayastor does not set values in g_spdk_app struct so we should not
+	 * call spdk_app_get_shm_id() and rather use something that is always
+	 * unique.
+	 */
+	snprintf(g_shm_name, sizeof(g_shm_name), "/spdk_iscsi_conns.%d", getpid());
 	g_conns_array_fd = shm_open(g_shm_name, O_RDWR | O_CREAT, 0600);
 	if (g_conns_array_fd < 0) {
 		SPDK_ERRLOG("could not shm_open %s\n", g_shm_name);


### PR DESCRIPTION
Mayastor does not set values in g_spdk_app because it does not use
spdk app framework. Using the data from there may cause problems.
In our case it is a crash in iscsi subsystem when running multiple
mayastor instances at once as they overwrite shared memory of one
another.