### PR TITLE
CAS-408: Re-enable io_uring support

### DIFF
--- a/include/spdk_internal/uring.h
+++ b/include/spdk_internal/uring.h
@@ -36,16 +36,4 @@
 
 #include <liburing.h>
 
-#ifndef __NR_sys_io_uring_enter
-#define __NR_sys_io_uring_enter         426
-#endif
-
-static int
-spdk_io_uring_enter(int ring_fd, unsigned int to_submit,
-		    unsigned int min_complete, unsigned int flags)
-{
-	return syscall(__NR_sys_io_uring_enter, ring_fd, to_submit,
-		       min_complete, flags, NULL, 0);
-}
-
 #endif /* SPDK_INTERNAL_URING_H */

--- a/module/bdev/uring/bdev_uring.c
+++ b/module/bdev/uring/bdev_uring.c
@@ -244,26 +244,20 @@ bdev_uring_group_poll(void *arg)
 	int count, ret;
 
 	to_submit = group_ch->io_pending;
-	to_complete = group_ch->io_inflight;
 
-	ret = 0;
 	if (to_submit > 0) {
 		/* If there are I/O to submit, use io_uring_submit here.
 		 * It will automatically call spdk_io_uring_enter appropriately. */
 		ret = io_uring_submit(&group_ch->uring);
+		if (ret < 0) {
+			return SPDK_POLLER_BUSY;
+		}
+
 		group_ch->io_pending = 0;
 		group_ch->io_inflight += to_submit;
-	} else if (to_complete > 0) {
-		/* If there are I/O in flight but none to submit, we need to
-		 * call io_uring_enter ourselves. */
-		ret = spdk_io_uring_enter(group_ch->uring.ring_fd, 0, 0,
-					  IORING_ENTER_GETEVENTS);
 	}
 
-	if (ret < 0) {
-		return SPDK_POLLER_BUSY;
-	}
-
+	to_complete = group_ch->io_inflight;
 	count = 0;
 	if (to_complete > 0) {
 		count = bdev_uring_reap(&group_ch->uring, to_complete);
@@ -426,7 +420,9 @@ bdev_uring_group_create_cb(void *io_device, void *ctx_buf)
 {
 	struct bdev_uring_group_channel *ch = ctx_buf;
 
-	if (io_uring_queue_init(SPDK_URING_QUEUE_DEPTH, &ch->uring, IORING_SETUP_IOPOLL) < 0) {
+	/* Do not use IORING_SETUP_IOPOLL until the Linux kernel can support not only
+	 * local devices but also devices attached from remote target */
+	if (io_uring_queue_init(SPDK_URING_QUEUE_DEPTH, &ch->uring, 0) < 0) {
 		SPDK_ERRLOG("uring I/O context setup failure\n");
 		return -1;
 	}

--- a/module/sock/posix/posix.c
+++ b/module/sock/posix/posix.c
@@ -1402,4 +1402,4 @@ static struct spdk_net_impl g_posix_net_impl = {
 	.set_opts	= posix_sock_impl_set_opts,
 };
 
-SPDK_NET_IMPL_REGISTER(posix, &g_posix_net_impl, DEFAULT_SOCK_PRIORITY);
+SPDK_NET_IMPL_REGISTER(posix, &g_posix_net_impl, DEFAULT_SOCK_PRIORITY + 3);


### PR DESCRIPTION
Allow the use of bdev/uring while maintaining the use of sock/posix so that distributions that use Linux kernel 5.4 (which is LTS) like Ubuntu 20.04 can benefit from bdev/uring.
Cherry-pick cca62c633fdd0911b26e5161c6b3a7bfacb33127 "bdev/uring: Do not use IORING_SETUP_IOPOLL" from upstream to also resolve CAS-129.