### PR TITLE
Support for unmap and write_zeroes in aio bdev module

### DIFF
--- a/module/bdev/aio/Makefile
+++ b/module/bdev/aio/Makefile
@@ -37,7 +37,7 @@ include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 SO_VER := 2
 SO_MINOR := 0
 
-C_SRCS = bdev_aio.c bdev_aio_rpc.c
+C_SRCS = bdev_aio.c bdev_aio_rpc.c bdev_aio_sync.c
 LIBNAME = bdev_aio
 LOCAL_SYS_LIBS = -laio
 

--- a/module/bdev/aio/bdev_aio.c
+++ b/module/bdev/aio/bdev_aio.c
@@ -45,11 +45,14 @@
 #include "spdk/json.h"
 #include "spdk/util.h"
 #include "spdk/string.h"
-
 #include "spdk/log.h"
 
 #include <sys/eventfd.h>
 #include <libaio.h>
+#include <linux/fs.h>
+
+#include "bdev_aio_task.h"
+#include "bdev_aio_sync.h"
 
 struct bdev_aio_io_channel {
 	uint64_t				io_inflight;
@@ -65,18 +68,15 @@ struct bdev_aio_group_channel {
 	TAILQ_HEAD(, bdev_aio_io_channel)	io_ch_head;
 };
 
-struct bdev_aio_task {
-	struct iocb			iocb;
-	uint64_t			len;
-	struct bdev_aio_io_channel	*ch;
-	TAILQ_ENTRY(bdev_aio_task)	link;
-};
+typedef int (*aio_range_fn)(int fd, uint64_t range[]);
 
 struct file_disk {
 	struct bdev_aio_task	*reset_task;
 	struct spdk_poller	*reset_retry_timer;
 	struct spdk_bdev	disk;
 	char			*filename;
+	aio_range_fn		unmap;
+	aio_range_fn		zero;
 	int			fd;
 	TAILQ_ENTRY(file_disk)  link;
 	bool			block_size_override;
@@ -120,46 +120,135 @@ static struct spdk_bdev_module aio_if = {
 
 SPDK_BDEV_MODULE_REGISTER(aio, &aio_if)
 
+#define ERROR(rc) (((rc) > 0) ? -(rc) : -EIO)
+
 static int
 bdev_aio_open(struct file_disk *disk)
 {
 	int fd;
 
-	fd = open(disk->filename, O_RDWR | O_DIRECT);
+	fd = open(disk->filename, (O_RDWR | O_DIRECT));
 	if (fd < 0) {
 		/* Try without O_DIRECT for non-disk files */
 		fd = open(disk->filename, O_RDWR);
 		if (fd < 0) {
-			SPDK_ERRLOG("open() failed (file:%s), errno %d: %s\n",
-				    disk->filename, errno, spdk_strerror(errno));
+			int rc = errno;
+
+			SPDK_ERRLOG("open(%s) failed, errno %d: %s\n",
+				    disk->filename, rc, spdk_strerror(rc));
 			disk->fd = -1;
-			return -1;
+			return ERROR(rc);
 		}
 	}
 
 	disk->fd = fd;
+	return 0;
+}
 
+/* zero region of a (sparse) file by creating a hole */
+static int
+aio_range_fallocate_sparse(int fd, uint64_t range[])
+{
+	return fallocate(fd, (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE), range[0], range[1]);
+}
+
+/* zero region of a file by writing zeros */
+static int
+aio_range_fallocate_zero(int fd, uint64_t range[])
+{
+	return fallocate(fd, (FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE), range[0], range[1]);
+}
+
+/* unmap region of a device */
+static int
+aio_range_unmap_discard(int fd, uint64_t range[])
+{
+	return ioctl(fd, BLKDISCARD, range);
+}
+
+/* zero region of a device */
+static int
+aio_range_unmap_zero(int fd, uint64_t range[])
+{
+	return ioctl(fd, BLKZEROOUT, range);
+}
+
+static int
+set_aio_range_functions(struct file_disk *disk)
+{
+	struct stat st;
+	int rc;
+
+	if (fstat(disk->fd, &st) < 0) {
+		rc = errno;
+		SPDK_ERRLOG("fstat(%s) failed, errno %d: %s\n",
+			    disk->filename, rc, spdk_strerror(rc));
+		disk->unmap = NULL;
+		disk->zero = NULL;
+		return ERROR(rc);
+	}
+
+	if (S_ISBLK(st.st_mode)) {
+		int discard = 0;
+
+		if (ioctl(disk->fd, BLKDISCARDZEROES, &discard) < 0) {
+			rc = errno;
+			SPDK_ERRLOG("ioctl(%s, BLKDISCARDZEROES) failed, errno %d: %s\n",
+				    disk->filename, rc, spdk_strerror(rc));
+			disk->unmap = NULL;
+			disk->zero = NULL;
+			return ERROR(rc);
+		}
+
+		if (discard) {
+			/* rely on fact that device guarantees that discarded blocks will be read back as zeros */
+			SPDK_NOTICELOG("device=%s unmap=discard zero=discard\n", disk->filename);
+			disk->unmap = aio_range_unmap_discard;
+			disk->zero = aio_range_unmap_discard;
+			return 0;
+		}
+
+		/* get kernel to zero blocks on our behalf */
+		SPDK_NOTICELOG("device=%s unmap=none zero=zero\n", disk->filename);
+		disk->unmap = NULL;
+		disk->zero = aio_range_unmap_zero;
+		return 0;
+	}
+
+	/* simulate unmap by creating a hole in (sparse) file */
+	disk->unmap = aio_range_fallocate_sparse;
+
+	/* FIXME: this should be configurable */
+
+	if (true) {
+		/* zero blocks by creating a hole in (sparse) file */
+		SPDK_NOTICELOG("file=%s unmap=sparse zero=sparse\n", disk->filename);
+		disk->zero = aio_range_fallocate_sparse;
+		return 0;
+	}
+
+	/* zero blocks by writing zeros */
+	SPDK_NOTICELOG("file=%s unmap=sparse zero=zero\n", disk->filename);
+	disk->zero = aio_range_fallocate_zero;
 	return 0;
 }
 
 static int
 bdev_aio_close(struct file_disk *disk)
 {
-	int rc;
-
-	if (disk->fd == -1) {
+	if (disk->fd < 0) {
 		return 0;
 	}
 
-	rc = close(disk->fd);
-	if (rc < 0) {
-		SPDK_ERRLOG("close() failed (fd=%d), errno %d: %s\n",
-			    disk->fd, errno, spdk_strerror(errno));
+	if (close(disk->fd) < 0) {
+		int rc = errno;
+
+		SPDK_ERRLOG("close(%d) failed, errno %d: %s\n",
+			    disk->fd, rc, spdk_strerror(rc));
 		return -1;
 	}
 
 	disk->fd = -1;
-
 	return 0;
 }
 
@@ -231,13 +320,134 @@ bdev_aio_writev(struct file_disk *fdisk, struct spdk_io_channel *ch,
 	return len;
 }
 
-static void
-bdev_aio_flush(struct file_disk *fdisk, struct bdev_aio_task *aio_task)
+static struct aio_request_ctx *
+create_aio_request_ctx(struct spdk_bdev_io *bdev_io, aio_request_fn fn, size_t ctx_size)
 {
-	int rc = fsync(fdisk->fd);
+	struct aio_request_ctx *request = malloc(sizeof(struct aio_request_ctx) + ctx_size);
 
-	spdk_bdev_io_complete(spdk_bdev_io_from_ctx(aio_task),
-			      rc == 0 ? SPDK_BDEV_IO_STATUS_SUCCESS : SPDK_BDEV_IO_STATUS_FAILED);
+	if (request != NULL) {
+		request->aio_task = (struct bdev_aio_task *)bdev_io->driver_ctx;
+		request->thread = spdk_get_thread();
+		request->fn = fn;
+	}
+
+	return request;
+}
+
+static void
+aio_send_range_request(struct spdk_bdev_io *bdev_io, struct file_disk *fdisk, aio_request_fn fn)
+{
+	struct aio_request_ctx *request;
+	struct aio_range_ctx *ctx;
+
+	request = create_aio_request_ctx(bdev_io, fn, sizeof(struct aio_range_ctx));
+
+	if (request == NULL) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+		return;
+	}
+
+	ctx = (struct aio_range_ctx *)request->ctx;
+
+	ctx->fdisk = fdisk;
+
+	ctx->offset_blocks = bdev_io->u.bdev.offset_blocks;
+	ctx->num_blocks = bdev_io->u.bdev.num_blocks;
+	ctx->blocklen = bdev_io->bdev->blocklen;
+
+	if (aio_send_request(request) < 0) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+		free(request);
+	}
+}
+
+static int
+aio_flush_request_fn(void *arg)
+{
+	struct aio_flush_ctx *ctx = arg;
+
+	SPDK_NOTICELOG("[flush] file=%s\n", ctx->fdisk->filename);
+
+	return fsync(ctx->fdisk->fd);
+}
+
+static void
+bdev_aio_flush(struct spdk_bdev_io *bdev_io)
+{
+	struct aio_request_ctx *request;
+	struct aio_flush_ctx *ctx;
+
+	request = create_aio_request_ctx(bdev_io, aio_flush_request_fn, sizeof(struct aio_flush_ctx));
+
+	if (request == NULL) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+		return;
+	}
+
+	ctx = (struct aio_flush_ctx *)request->ctx;
+
+	ctx->fdisk = bdev_io->bdev->ctxt;
+
+	if (aio_send_request(request) < 0) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+		free(request);
+	}
+}
+
+static int
+aio_unmap_request_fn(void *arg)
+{
+	struct aio_range_ctx *ctx = arg;
+	uint64_t range[2];
+
+	range[0] = ctx->offset_blocks * ctx->blocklen;
+	range[1] = ctx->num_blocks * ctx->blocklen;
+
+	SPDK_NOTICELOG("[unmap] file=%s range=%" PRIu64 ",%" PRIu64 "\n",
+		       ctx->fdisk->filename, range[0], range[1]);
+
+	return ctx->fdisk->unmap(ctx->fdisk->fd, range);
+}
+
+static void
+bdev_aio_unmap(struct spdk_bdev_io *bdev_io)
+{
+	struct file_disk *fdisk = bdev_io->bdev->ctxt;
+
+	if (fdisk->unmap == NULL) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+		return;
+	}
+
+	aio_send_range_request(bdev_io, fdisk, aio_unmap_request_fn);
+}
+
+static int
+aio_zero_request_fn(void *arg)
+{
+	struct aio_range_ctx *ctx = arg;
+	uint64_t range[2];
+
+	range[0] = ctx->offset_blocks * ctx->blocklen;
+	range[1] = ctx->num_blocks * ctx->blocklen;
+
+	SPDK_NOTICELOG("[zero] file=%s range=%" PRIu64 ",%" PRIu64 "\n",
+		       ctx->fdisk->filename, range[0], range[1]);
+
+	return ctx->fdisk->zero(ctx->fdisk->fd, range);
+}
+
+static void
+bdev_aio_zero(struct spdk_bdev_io *bdev_io)
+{
+	struct file_disk *fdisk = bdev_io->bdev->ctxt;
+
+	if (fdisk->zero == NULL) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+		return;
+	}
+
+	aio_send_range_request(bdev_io, fdisk, aio_zero_request_fn);
 }
 
 static int
@@ -479,7 +689,8 @@ bdev_aio_get_buf_cb(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io,
 	}
 }
 
-static int _bdev_aio_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
+static void
+bdev_aio_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
 {
 	switch (bdev_io->type) {
 	/* Read and write operations must be performed on buffers aligned to
@@ -489,24 +700,26 @@ static int _bdev_aio_submit_request(struct spdk_io_channel *ch, struct spdk_bdev
 	case SPDK_BDEV_IO_TYPE_WRITE:
 		spdk_bdev_io_get_buf(bdev_io, bdev_aio_get_buf_cb,
 				     bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen);
-		return 0;
+		break;
+
 	case SPDK_BDEV_IO_TYPE_FLUSH:
-		bdev_aio_flush((struct file_disk *)bdev_io->bdev->ctxt,
-			       (struct bdev_aio_task *)bdev_io->driver_ctx);
-		return 0;
+		bdev_aio_flush(bdev_io);
+		break;
 
 	case SPDK_BDEV_IO_TYPE_RESET:
 		bdev_aio_reset((struct file_disk *)bdev_io->bdev->ctxt,
 			       (struct bdev_aio_task *)bdev_io->driver_ctx);
-		return 0;
-	default:
-		return -1;
-	}
-}
+		break;
 
-static void bdev_aio_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
-{
-	if (_bdev_aio_submit_request(ch, bdev_io) < 0) {
+	case SPDK_BDEV_IO_TYPE_WRITE_ZEROES:
+		bdev_aio_zero(bdev_io);
+		break;
+
+	case SPDK_BDEV_IO_TYPE_UNMAP:
+		bdev_aio_unmap(bdev_io);
+		break;
+
+	default:
 		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
 	}
 }
@@ -520,6 +733,12 @@ bdev_aio_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type)
 	case SPDK_BDEV_IO_TYPE_FLUSH:
 	case SPDK_BDEV_IO_TYPE_RESET:
 		return true;
+
+	case SPDK_BDEV_IO_TYPE_WRITE_ZEROES:
+		return (((struct file_disk *)ctx)->zero != NULL);
+
+	case SPDK_BDEV_IO_TYPE_UNMAP:
+		return (((struct file_disk *)ctx)->unmap != NULL);
 
 	default:
 		return false;
@@ -698,9 +917,14 @@ create_aio_bdev(const char *name, const char *filename, uint32_t block_size)
 		goto error_return;
 	}
 
-	if (bdev_aio_open(fdisk)) {
-		SPDK_ERRLOG("Unable to open file %s. fd: %d errno: %d\n", filename, fdisk->fd, errno);
-		rc = -errno;
+	rc = bdev_aio_open(fdisk);
+	if (rc < 0) {
+		SPDK_ERRLOG("Unable to open file %s, errno %d\n", filename, -rc);
+		goto error_return;
+	}
+
+	rc = set_aio_range_functions(fdisk);
+	if (rc < 0) {
 		goto error_return;
 	}
 
@@ -830,13 +1054,14 @@ bdev_aio_initialize(void)
 {
 	spdk_io_device_register(&aio_if, bdev_aio_group_create_cb, bdev_aio_group_destroy_cb,
 				sizeof(struct bdev_aio_group_channel), "aio_module");
-
+	aio_sync_init();
 	return 0;
 }
 
 static void
 bdev_aio_fini(void)
 {
+	aio_sync_fini();
 	spdk_io_device_unregister(&aio_if, NULL);
 }
 

--- a/module/bdev/aio/bdev_aio_sync.c
+++ b/module/bdev/aio/bdev_aio_sync.c
@@ -1,0 +1,169 @@
+#include "bdev_aio.h"
+#include "spdk/env.h"
+#include "spdk/stdinc.h"
+#include "spdk/thread.h"
+#include "spdk/bdev_module.h"
+#include "spdk/log.h"
+
+#include <libaio.h>
+
+#include "bdev_aio_task.h"
+#include "bdev_aio_sync.h"
+
+#define MAX_QUEUE_LEN 1024
+
+static struct spdk_ring *g_blocking_ring = NULL;
+static pthread_t g_blocking_worker_thread;
+static pthread_mutex_t g_mutex;
+static pthread_cond_t g_cond;
+static bool g_exit;
+
+static void
+aio_complete(struct spdk_bdev_io *bdev_io, int status)
+{
+	spdk_bdev_io_complete(bdev_io,
+			      (status == 0) ? SPDK_BDEV_IO_STATUS_SUCCESS : SPDK_BDEV_IO_STATUS_FAILED);
+}
+
+static void
+aio_call_complete_fn(void *arg)
+{
+	struct aio_request_ctx *request = arg;
+
+	aio_complete(spdk_bdev_io_from_ctx(request->aio_task), request->status);
+
+	free(arg);
+}
+
+static void
+aio_call_request_fn(void *arg)
+{
+	struct aio_request_ctx *request = arg;
+
+	request->status = request->fn(request->ctx);
+
+	spdk_thread_send_msg(request->thread, aio_call_complete_fn, request);
+}
+
+#define BATCH_SIZE 64
+
+static void *
+aio_blocking_worker(void *arg)
+{
+	void *message[BATCH_SIZE];
+	size_t count;
+	size_t i;
+
+	SPDK_NOTICELOG("aio_blocking_worker started on core:%d\n", sched_getcpu());
+
+	pthread_mutex_lock(&g_mutex);
+
+	for (;;) {
+		for (;;) {
+			count = spdk_ring_dequeue(g_blocking_ring, message, BATCH_SIZE);
+
+			if (count == 0) {
+				break;
+			}
+
+			pthread_mutex_unlock(&g_mutex);
+
+			for (i = 0; i < count; i++) {
+				aio_call_request_fn(message[i]);
+			}
+
+			pthread_mutex_lock(&g_mutex);
+		}
+
+		if (g_exit) {
+			break;
+		}
+
+		pthread_cond_wait(&g_cond, &g_mutex);
+	}
+
+	pthread_mutex_unlock(&g_mutex);
+
+	return NULL;
+}
+
+int
+aio_send_request(void *message)
+{
+	size_t count = spdk_ring_count(g_blocking_ring);
+
+	if (spdk_ring_enqueue(g_blocking_ring, &message, 1, NULL) == 0) {
+		return -1;
+	}
+
+	if (count == 0) {
+		/* wake up worker thread */
+		pthread_mutex_lock(&g_mutex);
+		pthread_cond_signal(&g_cond);
+		pthread_mutex_unlock(&g_mutex);
+	}
+
+	return 0;
+}
+
+static
+void _set_affinity(pthread_attr_t *attr)
+{
+	cpu_set_t cpuset;
+	unsigned i, cores;
+
+	CPU_ZERO(&cpuset);
+
+	cores = sysconf(_SC_NPROCESSORS_CONF);
+
+	for (i = 0; i < cores; i++) {
+		CPU_SET(i, &cpuset);
+	}
+
+	SPDK_ENV_FOREACH_CORE(i) {
+		CPU_CLR(i, &cpuset);
+	}
+
+	if (CPU_COUNT(&cpuset) > 0) {
+		pthread_attr_setaffinity_np(attr, sizeof(cpu_set_t), &cpuset);
+	}
+}
+
+void
+aio_sync_init(void)
+{
+	pthread_attr_t attr;
+
+	g_blocking_ring = spdk_ring_create(SPDK_RING_TYPE_MP_SC, MAX_QUEUE_LEN, SPDK_ENV_SOCKET_ID_ANY);
+
+	g_exit = false;
+
+	pthread_mutex_init(&g_mutex, NULL);
+
+	pthread_cond_init(&g_cond, NULL);
+
+	pthread_attr_init(&attr);
+
+	_set_affinity(&attr);
+
+	pthread_create(&g_blocking_worker_thread, &attr, aio_blocking_worker, NULL);
+
+	pthread_attr_destroy(&attr);
+}
+
+void
+aio_sync_fini(void)
+{
+	pthread_mutex_lock(&g_mutex);
+	g_exit = true;
+	pthread_cond_signal(&g_cond);
+	pthread_mutex_unlock(&g_mutex);
+
+	pthread_join(g_blocking_worker_thread, NULL);
+
+	spdk_ring_free(g_blocking_ring);
+
+	pthread_cond_destroy(&g_cond);
+
+	pthread_mutex_destroy(&g_mutex);
+}

--- a/module/bdev/aio/bdev_aio_sync.h
+++ b/module/bdev/aio/bdev_aio_sync.h
@@ -1,0 +1,26 @@
+
+typedef int (*aio_request_fn)(void *arg);
+
+struct aio_request_ctx {
+	struct bdev_aio_task	*aio_task;
+	struct spdk_thread	*thread;
+	aio_request_fn		fn;
+	int			status;
+	char			ctx[0];
+};
+
+struct aio_flush_ctx {
+	struct file_disk	*fdisk;
+};
+
+struct aio_range_ctx {
+	struct file_disk	*fdisk;
+	uint64_t		offset_blocks;
+	uint64_t		num_blocks;
+	uint32_t		blocklen;
+};
+
+int aio_send_request(void *message);
+
+void aio_sync_init(void);
+void aio_sync_fini(void);

--- a/module/bdev/aio/bdev_aio_task.h
+++ b/module/bdev/aio/bdev_aio_task.h
@@ -1,0 +1,7 @@
+
+struct bdev_aio_task {
+	struct iocb			iocb;
+	uint64_t			len;
+	struct bdev_aio_io_channel	*ch;
+	TAILQ_ENTRY(bdev_aio_task)	link;
+};


### PR DESCRIPTION
Modify aio module to perform blocking operations (fsync + unmap) in a separate thread.
Support both unmap and write_zeroes I/O requests.

This is a resubmit of earlier PR including all incremental changes.