### PR TITLE
dpdkbuild: Fix Nix DPDK build on arm64 machine

### DIFF
--- a/dpdkbuild/Makefile
+++ b/dpdkbuild/Makefile
@@ -93,7 +93,12 @@ DPDK_LIBS += cryptodev mbuf cmdline meter hash vhost
 # raid5 deps
 DPDK_LIBS += hash rcu
 
+# Nix build only support generic machine now for aarch64
+ifeq ($(TARGET_MACHINE),aarch64)
+DPDK_OPTS += -Dmachine=generic
+else
 DPDK_OPTS += -Dmachine=$(TARGET_ARCHITECTURE)
+endif
 
 ifneq ($(CONFIG_CROSS_PREFIX),)
 ifeq ($(findstring mingw,$(CONFIG_CROSS_PREFIX)),mingw)


### PR DESCRIPTION
Note that, Mayastor builds its own Nix DPDK pkg in SPDK pkg, and nix DPDK build only support generic machine for arm64. 
We can not sent this PR to SPDK upstream, because SPDK upstream is not assume to build DPDK on Nix.

See upstream Nix related fix and bug:
https://github.com/NixOS/nixpkgs/commit/5ff289f39e7e3a30298ea7920337480d00988510
https://github.com/NixOS/nixpkgs/issues/154492

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>

This PR is related to Mayastor arm64 support: https://github.com/openebs/mayastor/issues/1063