### PR TITLE
fix(nvme-ptpl): don't error out when there's no holder

### DIFF
--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -835,8 +835,8 @@ int spdk_bdev_read(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
  *   * -ENOMEM - spdk_bdev_io buffer cannot be allocated
  */
 int spdk_bdev_read_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-                              void *buf, uint64_t offset, uint64_t nbytes,
-                              spdk_bdev_io_completion_cb cb, void *cb_arg,
+			      void *buf, uint64_t offset, uint64_t nbytes,
+			      spdk_bdev_io_completion_cb cb, void *cb_arg,
 			      uint32_t ext_io_flags);
 
 /**
@@ -997,11 +997,11 @@ int spdk_bdev_readv_blocks(struct spdk_bdev_desc *desc, struct spdk_io_channel *
  *   * -EINVAL - offset_blocks and/or num_blocks are out of range
  *   * -ENOMEM - spdk_bdev_io buffer cannot be allocated
  */
- int spdk_bdev_readv_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-				       struct iovec *iov, int iovcnt,
-				       uint64_t offset_blocks, uint64_t num_blocks,
-				       spdk_bdev_io_completion_cb cb, void *cb_arg,
-				       uint32_t ext_io_flags);
+int spdk_bdev_readv_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
+				      struct iovec *iov, int iovcnt,
+				      uint64_t offset_blocks, uint64_t num_blocks,
+				      spdk_bdev_io_completion_cb cb, void *cb_arg,
+				      uint32_t ext_io_flags);
 
 /**
  * Submit a read request to the bdev on the given channel. This differs from

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -4142,7 +4142,7 @@ static int
 bdev_read_blocks_with_md(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch, void *buf,
 			 void *md_buf, uint64_t offset_blocks, uint64_t num_blocks,
 			 spdk_bdev_io_completion_cb cb, void *cb_arg,
-                         uint32_t ext_io_flags)
+			 uint32_t ext_io_flags)
 {
 	struct spdk_bdev *bdev = spdk_bdev_desc_get_bdev(desc);
 	struct spdk_bdev_io *bdev_io;
@@ -4185,8 +4185,8 @@ spdk_bdev_read(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
 
 int
 spdk_bdev_read_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-                          void *buf, uint64_t offset, uint64_t nbytes,
-                          spdk_bdev_io_completion_cb cb, void *cb_arg,
+			  void *buf, uint64_t offset, uint64_t nbytes,
+			  spdk_bdev_io_completion_cb cb, void *cb_arg,
 			  uint32_t ext_io_flags)
 {
 	uint64_t offset_blocks, num_blocks;
@@ -4196,7 +4196,8 @@ spdk_bdev_read_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *c
 		return -EINVAL;
 	}
 
-	return spdk_bdev_read_blocks_with_flags(desc, ch, buf, offset_blocks, num_blocks, cb, cb_arg, ext_io_flags);
+	return spdk_bdev_read_blocks_with_flags(desc, ch, buf, offset_blocks, num_blocks, cb, cb_arg,
+						ext_io_flags);
 }
 
 int
@@ -4209,11 +4210,12 @@ spdk_bdev_read_blocks(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
 
 int
 spdk_bdev_read_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-                                 void *buf, uint64_t offset_blocks, uint64_t num_blocks,
-                                 spdk_bdev_io_completion_cb cb, void *cb_arg,
-			         uint32_t ext_io_flags)
+				 void *buf, uint64_t offset_blocks, uint64_t num_blocks,
+				 spdk_bdev_io_completion_cb cb, void *cb_arg,
+				 uint32_t ext_io_flags)
 {
-	return bdev_read_blocks_with_md(desc, ch, buf, NULL, offset_blocks, num_blocks, cb, cb_arg, ext_io_flags);
+	return bdev_read_blocks_with_md(desc, ch, buf, NULL, offset_blocks, num_blocks, cb, cb_arg,
+					ext_io_flags);
 }
 
 int

--- a/lib/nvmf/subsystem.c
+++ b/lib/nvmf/subsystem.c
@@ -1707,7 +1707,7 @@ spdk_nvmf_subsystem_add_ns_ext(struct spdk_nvmf_subsystem *subsystem, const char
 		if (!rc) {
 			rc = nvmf_ns_reservation_restore(ns, &info);
 			if (rc) {
-				SPDK_ERRLOG("Subsystem restore reservation failed\n");
+				SPDK_ERRLOG("Subsystem restore reservation failed (%d)\n", rc);
 				goto err_ns_reservation_restore;
 			}
 		}
@@ -2161,7 +2161,6 @@ nvmf_ns_reservation_restore(struct spdk_nvmf_ns *ns, struct spdk_nvmf_reservatio
 	uint32_t i;
 	struct spdk_nvmf_registrant *reg, *holder = NULL;
 	struct spdk_uuid bdev_uuid, holder_uuid;
-	bool rkey_flag = false;
 
 	SPDK_DEBUGLOG(nvmf, "NSID %u, PTPL %u, Number of registrants %u\n",
 		      ns->nsid, info->ptpl_activated, info->num_regs);
@@ -2169,16 +2168,6 @@ nvmf_ns_reservation_restore(struct spdk_nvmf_ns *ns, struct spdk_nvmf_reservatio
 	/* it's not an error */
 	if (!info->ptpl_activated || !info->num_regs) {
 		return 0;
-	}
-
-	/* Check info->crkey exist or not in info->registrants[i].rkey */
-	for (i = 0; i < info->num_regs; i++) {
-		if (info->crkey == info->registrants[i].rkey) {
-			rkey_flag = true;
-		}
-	}
-	if (!rkey_flag) {
-		return -EINVAL;
 	}
 
 	spdk_uuid_parse(&bdev_uuid, info->bdev_uuid);
@@ -2206,14 +2195,18 @@ nvmf_ns_reservation_restore(struct spdk_nvmf_ns *ns, struct spdk_nvmf_reservatio
 		spdk_uuid_parse(&reg->hostid, info->registrants[i].host_uuid);
 		reg->rkey = info->registrants[i].rkey;
 		TAILQ_INSERT_TAIL(&ns->registrants, reg, link);
-		if (!spdk_uuid_compare(&holder_uuid, &reg->hostid)) {
+		if (info->crkey && !spdk_uuid_compare(&holder_uuid, &reg->hostid)) {
 			holder = reg;
 		}
 		SPDK_DEBUGLOG(nvmf, "Registrant RKEY 0x%"PRIx64", Host UUID %s\n",
 			      info->registrants[i].rkey, info->registrants[i].host_uuid);
 	}
 
-	if (nvmf_ns_reservation_all_registrants_type(ns)) {
+	/* if current key was zero then there's no holder */
+	if (!info->crkey) {
+		ns->holder = NULL;
+		ns->rtype = 0;
+	} else if (nvmf_ns_reservation_all_registrants_type(ns)) {
 		ns->holder = TAILQ_FIRST(&ns->registrants);
 	} else {
 		ns->holder = holder;

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -1055,7 +1055,7 @@ cleanup:
 
 SPDK_RPC_REGISTER("bdev_lvol_get_lvstores", rpc_bdev_lvol_get_lvstores, SPDK_RPC_RUNTIME)
 
-//SPDK_RPC_REGISTER_ALIAS_DEPRECATED(bdev_lvol_get_lvstores, get_lvol_stores)
+/* SPDK_RPC_REGISTER_ALIAS_DEPRECATED(bdev_lvol_get_lvstores, get_lvol_stores) */
 
 struct rpc_construct_ms_lvol_bdev {
 	char *uuid;


### PR DESCRIPTION
When loading the reservation file, the restore was erroring out when there was no holder. This is not an error case, as it might be that no one was the holder prior to power loss. Check if there was any holder and if not, simply leave the namespace in similar state.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>