### PR TITLE
fix(qpair): asynchronous connect for nvme qpairs

### DIFF
--- a/include/spdk/nvme.h
+++ b/include/spdk/nvme.h
@@ -63,6 +63,8 @@ extern "C" {
  */
 struct spdk_nvme_ctrlr;
 
+struct spdk_nvme_qpair;
+
 /**
  * NVMe controller initialization options.
  *
@@ -301,6 +303,29 @@ struct spdk_nvme_accel_fn_table {
 	/** The accelerated crc32c function. */
 	void (*submit_accel_crc32c)(void *ctx, uint32_t *dst, struct iovec *iov,
 				    uint32_t iov_cnt, uint32_t seed, spdk_nvme_accel_completion_cb cb_fn, void *cb_arg);
+};
+
+/**
+ * I/O qpair connection callback.
+ *
+ * \param qpair Opaque handle to the qpair to connect.
+ * \param cb_arg Opaque value passed to spdk_nvme_connect_cb().
+ */
+typedef void (*spdk_io_qpair_connect_cb)(struct spdk_nvme_qpair *qpair, void *cb_arg);
+
+enum io_qpair_connect_state {
+	INIT,               /* Newly initiated connection. */
+	WAIT_FOR_CONNECT,   /* Connection initiated. */
+	CONNECTED,          /* Connection successfully completed. */
+};
+
+/**
+ * Context for asynchronous I/O qpair connection.
+ */
+struct spdk_nvme_io_qpair_connect_ctx {
+	spdk_io_qpair_connect_cb        cb_fn;
+	void                            *cb_arg;
+	enum io_qpair_connect_state     state;
 };
 
 /**
@@ -1621,6 +1646,49 @@ struct spdk_nvme_qpair *spdk_nvme_ctrlr_alloc_io_qpair(struct spdk_nvme_ctrlr *c
  *
  */
 int spdk_nvme_ctrlr_connect_io_qpair(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nvme_qpair *qpair);
+
+/**
+ * Initiate connection for an I/O qpair.
+ *
+ * This function prepares a context to be polled asynchronously to complete
+ * connection.
+ *
+ * \param ctrlr NVMe controller for which to connect I/O qpair.
+ * \param qpair Opaque handle to the qpair to connect.
+ * \param cb_fn Callback function invoked when the I/O is connected.
+ * \param cb_arg Argument passed to callback function.
+ *
+ * \return probe context on success, NULL on failure.
+ *
+ */
+struct spdk_nvme_io_qpair_connect_ctx *spdk_nvme_ctrlr_connect_io_qpair_async(
+	struct spdk_nvme_ctrlr *ctrlr,
+	struct spdk_nvme_qpair *qpair,
+	spdk_io_qpair_connect_cb cb_fn,
+	void *cb_arg);
+
+/**
+ * Proceed with connecting I/O qpair associated with the connect context.
+ *
+ * The probe context is one returned from a previous call to
+ * spdk_nvme_ctrlr_connect_io_qpair_async().  Users must call this function on the
+ * probe context until it returns 0.
+ * Note that target I/O qpair must be created with asynchronous mode turned on (via
+ * spdk_nvme_io_qpair_opts).
+ *
+ * \param connect_ctx Context used to track probe actions.
+ *
+ * \return 0 if all probe operations are complete; the completion callback is called
+ * and the connection ctx is freed and is no longer valid.
+ * \return 1 if there are still pending connect operations; user must call
+ * spdk_nvme_ctrlr_io_qpair_connect_poll_async again to continue progress.
+ * \return a negative errno value returned indicates a failure during polling.
+ * In case of such errors the completion callback is not called, connection ctx
+ * is freed and is no longer valid.
+ */
+int spdk_nvme_ctrlr_io_qpair_connect_poll_async(
+	struct spdk_nvme_qpair *qpair,
+	struct spdk_nvme_io_qpair_connect_ctx *probe_ctx);
 
 /**
  * Disconnect the given I/O qpair.

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -433,6 +433,104 @@ nvme_ctrlr_create_io_qpair(struct spdk_nvme_ctrlr *ctrlr,
 	return qpair;
 }
 
+struct spdk_nvme_io_qpair_connect_ctx *spdk_nvme_ctrlr_connect_io_qpair_async(
+	struct spdk_nvme_ctrlr *ctrlr,
+	struct spdk_nvme_qpair *qpair,
+	spdk_io_qpair_connect_cb cb_fn,
+	void *cb_arg)
+{
+	struct spdk_nvme_io_qpair_connect_ctx *poll_ctx;
+
+	// Check if I/O qpair supports asynchronous qpair connection.
+	if (!qpair->async) {
+		SPDK_ERRLOG("asynchronous mode is turned of for I/O qpair 0x%p", qpair);
+		return NULL;
+	}
+
+	poll_ctx = calloc(1, sizeof(*poll_ctx));
+	if (!poll_ctx) {
+		return NULL;
+	}
+
+	poll_ctx->cb_fn = cb_fn;
+	poll_ctx->cb_arg = cb_arg;
+	poll_ctx->state = INIT;
+
+	return poll_ctx;
+}
+
+int spdk_nvme_ctrlr_io_qpair_connect_poll_async(
+	struct spdk_nvme_qpair *qpair,
+	struct spdk_nvme_io_qpair_connect_ctx *probe_ctx)
+{
+	int rc = 0;
+	int n;
+
+	switch (probe_ctx->state) {
+	case INIT:
+		// Check if I/O qpair supports asynchronous qpair connection.
+		if (!qpair->async) {
+			SPDK_ERRLOG("asynchronous mode is turned off for I/O qpair 0x%p", qpair);
+			rc = -ENXIO;
+			goto out_error;
+		}
+
+		// Initiate I/O qpair connection.
+		rc = nvme_transport_ctrlr_connect_qpair(qpair->ctrlr, qpair);
+		if (rc != 0) {
+			goto out_error;
+		}
+		probe_ctx->state = WAIT_FOR_CONNECT;
+		break;
+	case WAIT_FOR_CONNECT:
+		n = spdk_nvme_qpair_process_completions(qpair, 0);
+
+		// Check for transport errors.
+		if (n < 0) {
+			rc = -n;
+			goto out_error;
+		}
+
+		switch (nvme_qpair_get_state(qpair)) {
+		case NVME_QPAIR_CONNECTING:
+			break;
+		case NVME_QPAIR_CONNECTED:
+			nvme_qpair_set_state(qpair, NVME_QPAIR_ENABLED);
+		/* fallthrough */
+		case NVME_QPAIR_ENABLED:
+			probe_ctx->state = CONNECTED;
+			goto out_notify;
+		case NVME_QPAIR_DISCONNECTING:
+			assert(qpair->async == true);
+			break;
+		case NVME_QPAIR_DISCONNECTED:
+		/* fallthrough */
+		default:
+			break;
+		}
+		break;
+	default:
+		// Should not get here in case of errors as polling should have stopped.
+		assert(false);
+	}
+
+	// Trigger the next polling round.
+	return 1;
+
+	// Report polling error and request to stop polling.
+out_error:
+	free(probe_ctx);
+	return rc;
+
+	// Notify the callback and request to stop polling.
+out_notify:
+	if (probe_ctx->cb_fn) {
+		probe_ctx->cb_fn(qpair, probe_ctx->cb_arg);
+	}
+	free(probe_ctx);
+	return 0;
+}
+
 int
 spdk_nvme_ctrlr_connect_io_qpair(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nvme_qpair *qpair)
 {


### PR DESCRIPTION
Added functions to support asynchronous connections for NVMe I/O qpairs:
  spdk_nvme_ctrlr_connect_io_qpair_async()
  spdk_nvme_ctrlr_io_qpair_connect_poll_async()
which allow non-blocking, poller-based connects for I/O qpairs.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>