### PR TITLE
Provide new API for registering callback for subsystem events

### DIFF
--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -410,6 +410,43 @@ typedef void (*spdk_nvmf_subsystem_state_change_done)(struct spdk_nvmf_subsystem
 		void *cb_arg, int status);
 
 /**
+ * List of subsystem events to be propaged downstream.
+ */
+typedef enum spdk_nvmf_subsystem_events_t {
+	/* Reserved */
+	SPDK_NVMF_SS_NONE = 0,
+	/** Initator connect event */
+	SPDK_NVMF_SS_INIATOR_CONNECT,
+	/** Initator disconnect event */
+	SPDK_NVMF_SS_INIATOR_DISCONNECT,
+	/** Initator timeout event */
+	SPDK_NVMF_SS_INIATOR_TIMEOUT
+} spdk_nvmf_subsystem_events;
+
+/**
+ * Function to be called on subsystem events.
+ *
+ * \param subsystem NVMe-oF subsystem that has events to report.
+ * \param cb_arg Argument passed by callback function.
+ * \param spdk_nvmf_subsystem_events subsystem event type.
+ */
+typedef void (*spdk_nvmf_subsystem_event_cb)(struct spdk_nvmf_subsystem *subsystem,
+		void *cb_arg,
+		spdk_nvmf_subsystem_events event);
+
+/**
+ * Register callback function to receive subsystem events.
+ *
+ * \param subsystem The NVMe-oF subsystem.
+ * \param cb_fn A function that will be called once the subsystem has changed state.
+ *
+ * \return 0 on success, or negated errno on failure.
+ */
+
+int spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem *subsystem,
+						spdk_nvmf_subsystem_event_cb cb);
+
+/**
  * Transition an NVMe-oF subsystem from Inactive to Active state.
  *
  * \param subsystem The NVMe-oF subsystem.

--- a/lib/nvmf/ctrlr.c
+++ b/lib/nvmf/ctrlr.c
@@ -209,8 +209,7 @@ nvmf_ctrlr_keep_alive_poll(void *ctx)
 					      nvmf_ctrlr_disconnect_qpairs_on_pg,
 					      ctrlr,
 					      nvmf_ctrlr_disconnect_qpairs_done);
-			if(ctrlr->subsys->nvmf_ss_event_cb)
-				notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_TIMEOUT);
+			notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_TIMEOUT);
 			return SPDK_POLLER_BUSY;
 		}
 	}
@@ -781,8 +780,7 @@ _nvmf_ctrlr_connect(struct spdk_nvmf_request *req)
 			rsp->status.sc = SPDK_NVME_SC_INTERNAL_DEVICE_ERROR;
 			return SPDK_NVMF_REQUEST_EXEC_STATUS_COMPLETE;
 		} else {
-			if(subsystem->nvmf_ss_event_cb)
-				notify_subsystem_events(subsystem, ctrlr, SPDK_NVMF_SS_INIATOR_CONNECT);
+			notify_subsystem_events(subsystem, ctrlr, SPDK_NVMF_SS_INIATOR_CONNECT);
 
 			return SPDK_NVMF_REQUEST_EXEC_STATUS_ASYNCHRONOUS;
 		}
@@ -1129,8 +1127,7 @@ nvmf_prop_set_cc(struct spdk_nvmf_ctrlr *ctrlr, uint32_t value)
 					      nvmf_ctrlr_disconnect_io_qpairs_on_pg,
 					      ctrlr,
 					      nvmf_ctrlr_cc_reset_shn_done);
-			if( ctrlr->subsys->nvmf_ss_event_cb )
-				notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
+			notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
 		}
 		diff.bits.en = 0;
 	}
@@ -1162,8 +1159,7 @@ nvmf_prop_set_cc(struct spdk_nvmf_ctrlr *ctrlr, uint32_t value)
 			/* From the time a shutdown is initiated the controller shall disable
 			 * Keep Alive timer */
 			nvmf_ctrlr_stop_keep_alive_timer(ctrlr);
-			if(ctrlr->subsys->nvmf_ss_event_cb)
-				notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
+			notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
 		} else if (cc.bits.shn == 0) {
 			ctrlr->vcprop.cc.bits.shn = 0;
 		} else {

--- a/lib/nvmf/ctrlr.c
+++ b/lib/nvmf/ctrlr.c
@@ -210,7 +210,7 @@ nvmf_ctrlr_keep_alive_poll(void *ctx)
 					      ctrlr,
 					      nvmf_ctrlr_disconnect_qpairs_done);
 			if(ctrlr->subsys->nvmf_ss_event_cb)
-				ctrlr->subsys->nvmf_ss_event_cb(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_TIMEOUT);
+				notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_TIMEOUT);
 			return SPDK_POLLER_BUSY;
 		}
 	}
@@ -782,7 +782,7 @@ _nvmf_ctrlr_connect(struct spdk_nvmf_request *req)
 			return SPDK_NVMF_REQUEST_EXEC_STATUS_COMPLETE;
 		} else {
 			if(subsystem->nvmf_ss_event_cb)
-				subsystem->nvmf_ss_event_cb(subsystem, ctrlr, SPDK_NVMF_SS_INIATOR_CONNECT);
+				notify_subsystem_events(subsystem, ctrlr, SPDK_NVMF_SS_INIATOR_CONNECT);
 
 			return SPDK_NVMF_REQUEST_EXEC_STATUS_ASYNCHRONOUS;
 		}
@@ -1130,7 +1130,7 @@ nvmf_prop_set_cc(struct spdk_nvmf_ctrlr *ctrlr, uint32_t value)
 					      ctrlr,
 					      nvmf_ctrlr_cc_reset_shn_done);
 			if( ctrlr->subsys->nvmf_ss_event_cb )
-				ctrlr->subsys->nvmf_ss_event_cb(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
+				notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
 		}
 		diff.bits.en = 0;
 	}
@@ -1163,7 +1163,7 @@ nvmf_prop_set_cc(struct spdk_nvmf_ctrlr *ctrlr, uint32_t value)
 			 * Keep Alive timer */
 			nvmf_ctrlr_stop_keep_alive_timer(ctrlr);
 			if(ctrlr->subsys->nvmf_ss_event_cb)
-				ctrlr->subsys->nvmf_ss_event_cb(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
+				notify_subsystem_events(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
 		} else if (cc.bits.shn == 0) {
 			ctrlr->vcprop.cc.bits.shn = 0;
 		} else {

--- a/lib/nvmf/ctrlr.c
+++ b/lib/nvmf/ctrlr.c
@@ -209,6 +209,8 @@ nvmf_ctrlr_keep_alive_poll(void *ctx)
 					      nvmf_ctrlr_disconnect_qpairs_on_pg,
 					      ctrlr,
 					      nvmf_ctrlr_disconnect_qpairs_done);
+			if(ctrlr->subsys->nvmf_ss_event_cb)
+				ctrlr->subsys->nvmf_ss_event_cb(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_TIMEOUT);
 			return SPDK_POLLER_BUSY;
 		}
 	}
@@ -779,6 +781,9 @@ _nvmf_ctrlr_connect(struct spdk_nvmf_request *req)
 			rsp->status.sc = SPDK_NVME_SC_INTERNAL_DEVICE_ERROR;
 			return SPDK_NVMF_REQUEST_EXEC_STATUS_COMPLETE;
 		} else {
+			if(subsystem->nvmf_ss_event_cb)
+				subsystem->nvmf_ss_event_cb(subsystem, ctrlr, SPDK_NVMF_SS_INIATOR_CONNECT);
+
 			return SPDK_NVMF_REQUEST_EXEC_STATUS_ASYNCHRONOUS;
 		}
 	} else {
@@ -1124,6 +1129,8 @@ nvmf_prop_set_cc(struct spdk_nvmf_ctrlr *ctrlr, uint32_t value)
 					      nvmf_ctrlr_disconnect_io_qpairs_on_pg,
 					      ctrlr,
 					      nvmf_ctrlr_cc_reset_shn_done);
+			if( ctrlr->subsys->nvmf_ss_event_cb )
+				ctrlr->subsys->nvmf_ss_event_cb(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
 		}
 		diff.bits.en = 0;
 	}
@@ -1155,6 +1162,8 @@ nvmf_prop_set_cc(struct spdk_nvmf_ctrlr *ctrlr, uint32_t value)
 			/* From the time a shutdown is initiated the controller shall disable
 			 * Keep Alive timer */
 			nvmf_ctrlr_stop_keep_alive_timer(ctrlr);
+			if(ctrlr->subsys->nvmf_ss_event_cb)
+				ctrlr->subsys->nvmf_ss_event_cb(ctrlr->subsys, ctrlr, SPDK_NVMF_SS_INIATOR_DISCONNECT);
 		} else if (cc.bits.shn == 0) {
 			ctrlr->vcprop.cc.bits.shn = 0;
 		} else {

--- a/lib/nvmf/nvmf_internal.h
+++ b/lib/nvmf/nvmf_internal.h
@@ -543,7 +543,12 @@ int nvmf_bdev_ctrlr_zcopy_start(struct spdk_bdev *bdev,
 void nvmf_bdev_ctrlr_zcopy_end(struct spdk_nvmf_request *req, bool commit);
 
 
-void notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
+static inline void notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
 						void *cb_arg,
-						spdk_nvmf_subsystem_events event);
+						spdk_nvmf_subsystem_events event)
+{
+	if (subsystem->nvmf_ss_event_cb)
+		subsystem->nvmf_ss_event_cb(subsystem, cb_arg, event);
+}
+
 #endif /* __NVMF_INTERNAL_H__ */

--- a/lib/nvmf/nvmf_internal.h
+++ b/lib/nvmf/nvmf_internal.h
@@ -542,4 +542,8 @@ int nvmf_bdev_ctrlr_zcopy_start(struct spdk_bdev *bdev,
  */
 void nvmf_bdev_ctrlr_zcopy_end(struct spdk_nvmf_request *req, bool commit);
 
+
+void notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
+						void *cb_arg,
+						spdk_nvmf_subsystem_events event);
 #endif /* __NVMF_INTERNAL_H__ */

--- a/lib/nvmf/nvmf_internal.h
+++ b/lib/nvmf/nvmf_internal.h
@@ -363,6 +363,7 @@ struct spdk_nvmf_subsystem {
 	 * It will be enough for ANA group to use the same size as namespaces.
 	 */
 	uint32_t					*ana_group;
+	spdk_nvmf_subsystem_event_cb nvmf_ss_event_cb;
 };
 
 int nvmf_poll_group_add_transport(struct spdk_nvmf_poll_group *group,

--- a/lib/nvmf/spdk_nvmf.map
+++ b/lib/nvmf/spdk_nvmf.map
@@ -21,6 +21,7 @@
 	spdk_nvmf_qpair_get_local_trid;
 	spdk_nvmf_qpair_get_listen_trid;
 	spdk_nvmf_subsystem_create;
+	spdk_nvmf_subsystem_register_for_event;
 	spdk_nvmf_subsystem_destroy;
 	spdk_nvmf_subsystem_start;
 	spdk_nvmf_subsystem_stop;

--- a/lib/nvmf/subsystem.c
+++ b/lib/nvmf/subsystem.c
@@ -338,6 +338,16 @@ spdk_nvmf_subsystem_create(struct spdk_nvmf_tgt *tgt,
 	return subsystem;
 }
 
+/* Register a callback function for the subsystem events*/
+int
+spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem *subsystem,
+						spdk_nvmf_subsystem_event_cb cb)
+{
+	subsystem->nvmf_ss_event_cb = cb;
+	SPDK_INFOLOG(nvmf, "Subsystem Event callback Registered for %s\n",subsystem->subnqn);
+	return 0;
+}
+
 /* Must hold subsystem->mutex while calling this function */
 static void
 nvmf_subsystem_remove_host(struct spdk_nvmf_subsystem *subsystem, struct spdk_nvmf_host *host)

--- a/lib/nvmf/subsystem.c
+++ b/lib/nvmf/subsystem.c
@@ -348,13 +348,6 @@ spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem *subsystem,
 	return 0;
 }
 
-void
-notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
-						void *cb_arg,
-						spdk_nvmf_subsystem_events event)
-{
-	subsystem->nvmf_ss_event_cb(subsystem, cb_arg, event);
-}
 /* Must hold subsystem->mutex while calling this function */
 static void
 nvmf_subsystem_remove_host(struct spdk_nvmf_subsystem *subsystem, struct spdk_nvmf_host *host)

--- a/lib/nvmf/subsystem.c
+++ b/lib/nvmf/subsystem.c
@@ -338,7 +338,7 @@ spdk_nvmf_subsystem_create(struct spdk_nvmf_tgt *tgt,
 	return subsystem;
 }
 
-/* Register a callback function for the subsystem events*/
+/* Register a callback function for the subsystem events */
 int
 spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem *subsystem,
 						spdk_nvmf_subsystem_event_cb cb)
@@ -348,6 +348,13 @@ spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem *subsystem,
 	return 0;
 }
 
+void
+notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
+						void *cb_arg,
+						spdk_nvmf_subsystem_events event)
+{
+	subsystem->nvmf_ss_event_cb(subsystem, cb_arg, event);
+}
 /* Must hold subsystem->mutex while calling this function */
 static void
 nvmf_subsystem_remove_host(struct spdk_nvmf_subsystem *subsystem, struct spdk_nvmf_host *host)


### PR DESCRIPTION
nexus is exported as nvmf target by creating a subsystem using spdk_nvmf_subsystem_create. 

We need an additional API from spdk something like  spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem  *subsystem, func *cb, void *args)    And once it is registered for events, it should call the callback function whenever any initiator connects or disconnects/timeout to the given subsystem