### PR TITLE
feat(lvol): support of user-defined attributes for volume snapshots

### DIFF
--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -48,6 +48,7 @@ extern "C" {
 struct spdk_bs_dev;
 struct spdk_lvol_store;
 struct spdk_lvol;
+struct spdk_xattr_descriptor;
 
 enum lvol_clear_method {
 	LVOL_CLEAR_WITH_DEFAULT = BLOB_CLEAR_WITH_DEFAULT,
@@ -74,6 +75,12 @@ struct spdk_lvs_opts {
 	enum lvs_clear_method	clear_method;
 	char			name[SPDK_LVS_NAME_MAX];
 	const char              *uuid;
+};
+
+struct spdk_xattr_descriptor {
+	char		*name;
+	void		*value;
+	uint16_t	value_len;
 };
 
 /**
@@ -218,6 +225,22 @@ int spdk_lvol_create_with_uuid(struct spdk_lvol_store *lvs, const char *name, ui
  */
 void spdk_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
 			       spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
+
+
+/**
+ * Create snapshot of given lvol.
+ *
+ * \param lvol Handle to lvol.
+ * \param snapshot_name Name of created snapshot.
+ * \param xattrs Optional set of attributes for snapshot.
+ * \param xattrs_count Number of attributes for snapshot.
+ * \param cb_fn Completion callback.
+ * \param cb_arg Completion callback custom arguments.
+ */
+void spdk_lvol_create_snapshot_ext(struct spdk_lvol *lvol, const char *snapshot_name,
+				   struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+				   spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
+
 
 /**
  * Create clone of given snapshot.

--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -444,7 +444,7 @@ typedef void (*spdk_nvmf_subsystem_event_cb)(struct spdk_nvmf_subsystem *subsyst
  */
 
 int spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem *subsystem,
-						spdk_nvmf_subsystem_event_cb cb);
+		spdk_nvmf_subsystem_event_cb cb);
 
 /**
  * Transition an NVMe-oF subsystem from Inactive to Active state.

--- a/include/spdk_internal/lvolstore.h
+++ b/include/spdk_internal/lvolstore.h
@@ -77,6 +77,8 @@ struct spdk_lvs_destroy_req {
 	struct spdk_lvol_store	*lvs;
 };
 
+struct spdk_xattr_descriptor;
+
 struct spdk_lvol_with_handle_req {
 	spdk_lvol_op_with_handle_complete cb_fn;
 	void				*cb_arg;

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -42,12 +42,25 @@
 /* Default blob channel opts for lvol */
 #define SPDK_LVOL_BLOB_OPTS_CHANNEL_OPS 512
 
+/**
+ * Maximum number of user-defined attributes for volume snapshot
+ * creation operations.
+ */
+#define SPDK_LVOL_MAX_SNAPSHOT_ATTRS 32
+
 #define LVOL_NAME "name"
 
 SPDK_LOG_REGISTER_COMPONENT(lvol)
 
 static TAILQ_HEAD(, spdk_lvol_store) g_lvol_stores = TAILQ_HEAD_INITIALIZER(g_lvol_stores);
 static pthread_mutex_t g_lvol_stores_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+struct xattr_value_ext_arg {
+	struct spdk_blob_xattr_opts snapshot_xattrs;
+	struct spdk_lvol *lvol;
+	struct spdk_xattr_descriptor *user_xattrs;
+	uint32_t user_xattrs_count;
+};
 
 static int
 add_lvs_to_list(struct spdk_lvol_store *lvs)
@@ -1007,6 +1020,38 @@ lvol_get_xattr_value(void *xattr_ctx, const char *name,
 	*value_len = 0;
 }
 
+static void
+lvol_get_xattr_value_ext(void *xattr_ctx, const char *name,
+			 const void **value, size_t *value_len)
+{
+	struct xattr_value_ext_arg *ext_arg = xattr_ctx;
+	struct spdk_lvol *lvol = ext_arg->lvol;
+	uint32_t i;
+
+	if (!strcmp(LVOL_NAME, name)) {
+		*value = lvol->name;
+		*value_len = SPDK_LVOL_NAME_MAX;
+		return;
+	}
+	if (!strcmp("uuid", name)) {
+		*value = lvol->uuid_str;
+		*value_len = sizeof(lvol->uuid_str);
+		return;
+	}
+
+	/* Find attribute among user-specific ones. */
+	for (i = 0; i < ext_arg->user_xattrs_count; i++) {
+		if (!strcmp(ext_arg->user_xattrs[i].name, name)) {
+			*value = ext_arg->user_xattrs[i].value;
+			*value_len = ext_arg->user_xattrs[i].value_len;
+			return;
+		}
+	}
+
+	*value = NULL;
+	*value_len = 0;
+}
+
 static int
 lvs_verify_lvol_name(struct spdk_lvol_store *lvs, const char *name)
 {
@@ -1120,17 +1165,49 @@ spdk_lvol_create_with_uuid(struct spdk_lvol_store *lvs, const char *name, uint64
 	return 0;
 }
 
-void
-spdk_lvol_create_snapshot(struct spdk_lvol *origlvol, const char *snapshot_name,
-			  spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+
+static void
+create_lvol_snapshot(struct spdk_lvol *origlvol, const char *snapshot_name,
+		     struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+		     spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {
 	struct spdk_lvol_store *lvs;
 	struct spdk_lvol *newlvol;
 	struct spdk_blob *origblob;
 	struct spdk_lvol_with_handle_req *req;
-	struct spdk_blob_xattr_opts snapshot_xattrs;
-	char *xattr_names[] = {LVOL_NAME, "uuid"};
+	struct xattr_value_ext_arg xattr_args;
+	char *xattr_names[SPDK_LVOL_MAX_SNAPSHOT_ATTRS + 2]; /* Extra default attributes. */
 	int rc;
+	size_t num_attrs = 2; /* Number of default attributes. */
+
+	if (xattrs_count > SPDK_LVOL_MAX_SNAPSHOT_ATTRS) {
+		SPDK_INFOLOG(lvol, "Number of snapshot sttributes too big: %d.\n", xattrs_count);
+		cb_fn(cb_arg, NULL, -EINVAL);
+		return;
+	}
+
+	if (xattrs_count > 0 && xattrs == NULL) {
+		SPDK_INFOLOG(lvol, "%d snapshot attributes specified but no attributes provided.\n", xattrs_count);
+		cb_fn(cb_arg, NULL, -EINVAL);
+		return;
+	}
+
+	memset(xattr_names, 0, sizeof(xattr_names));
+
+	/* Generic snapshot attributes. */
+	xattr_names[0] = LVOL_NAME;
+	xattr_names[1] = "uuid";
+
+	/* User-defined snapshot attributes. */
+	if (xattrs_count > 0) {
+		uint32_t i;
+
+		for (i = 0; i < xattrs_count; i++) {
+			xattr_names[i + 2] = xattrs[i].name;
+		}
+
+		num_attrs += xattrs_count;
+	}
 
 	if (origlvol == NULL) {
 		SPDK_INFOLOG(lvol, "Lvol not provided.\n");
@@ -1172,16 +1249,40 @@ spdk_lvol_create_snapshot(struct spdk_lvol *origlvol, const char *snapshot_name,
 	TAILQ_INSERT_TAIL(&newlvol->lvol_store->pending_lvols, newlvol, link);
 	spdk_uuid_generate(&newlvol->uuid);
 	spdk_uuid_fmt_lower(newlvol->uuid_str, sizeof(newlvol->uuid_str), &newlvol->uuid);
-	snapshot_xattrs.count = SPDK_COUNTOF(xattr_names);
-	snapshot_xattrs.ctx = newlvol;
-	snapshot_xattrs.names = xattr_names;
-	snapshot_xattrs.get_value = lvol_get_xattr_value;
+
+	/* Setup context for resolving all snapshot attributes. */
+	memset(&xattr_args, 0, sizeof(xattr_args));
+
+	xattr_args.snapshot_xattrs.count = num_attrs;
+	xattr_args.snapshot_xattrs.ctx = &xattr_args;
+	xattr_args.snapshot_xattrs.names = xattr_names;
+	xattr_args.snapshot_xattrs.get_value = lvol_get_xattr_value_ext;
+
+	xattr_args.lvol = newlvol;
+	xattr_args.user_xattrs = xattrs;
+	xattr_args.user_xattrs_count = xattrs_count;
+
 	req->lvol = newlvol;
 	req->cb_fn = cb_fn;
 	req->cb_arg = cb_arg;
 
-	spdk_bs_create_snapshot(lvs->blobstore, spdk_blob_get_id(origblob), &snapshot_xattrs,
+	spdk_bs_create_snapshot(lvs->blobstore, spdk_blob_get_id(origblob), &xattr_args.snapshot_xattrs,
 				lvol_create_cb, req);
+}
+
+void
+spdk_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
+			  spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+{
+	create_lvol_snapshot(lvol, snapshot_name, NULL, 0, cb_fn, cb_arg);
+}
+
+void
+spdk_lvol_create_snapshot_ext(struct spdk_lvol *lvol, const char *snapshot_name,
+			      struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+			      spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+{
+	create_lvol_snapshot(lvol, snapshot_name, xattrs, xattrs_count, cb_fn, cb_arg);
 }
 
 void

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -9,6 +9,7 @@
 	spdk_lvs_destroy;
 	spdk_lvol_create;
 	spdk_lvol_create_snapshot;
+	spdk_lvol_create_snapshot_ext;
 	spdk_lvol_create_clone;
 	spdk_lvol_rename;
 	spdk_lvol_deletable;

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -441,7 +441,7 @@ struct spdk_nvme_io_qpair_connect_ctx *spdk_nvme_ctrlr_connect_io_qpair_async(
 {
 	struct spdk_nvme_io_qpair_connect_ctx *poll_ctx;
 
-	// Check if I/O qpair supports asynchronous qpair connection.
+	/* Check if I/O qpair supports asynchronous qpair connection. */
 	if (!qpair->async) {
 		SPDK_ERRLOG("asynchronous mode is turned of for I/O qpair 0x%p", qpair);
 		return NULL;
@@ -468,14 +468,14 @@ int spdk_nvme_ctrlr_io_qpair_connect_poll_async(
 
 	switch (probe_ctx->state) {
 	case INIT:
-		// Check if I/O qpair supports asynchronous qpair connection.
+		/* Check if I/O qpair supports asynchronous qpair connection. */
 		if (!qpair->async) {
 			SPDK_ERRLOG("asynchronous mode is turned off for I/O qpair 0x%p", qpair);
 			rc = -ENXIO;
 			goto out_error;
 		}
 
-		// Initiate I/O qpair connection.
+		/* Initiate I/O qpair connection. */
 		rc = nvme_transport_ctrlr_connect_qpair(qpair->ctrlr, qpair);
 		if (rc != 0) {
 			goto out_error;
@@ -485,7 +485,7 @@ int spdk_nvme_ctrlr_io_qpair_connect_poll_async(
 	case WAIT_FOR_CONNECT:
 		n = spdk_nvme_qpair_process_completions(qpair, 0);
 
-		// Check for transport errors.
+		/* Check for transport errors. */
 		if (n < 0) {
 			rc = -n;
 			goto out_error;
@@ -510,19 +510,19 @@ int spdk_nvme_ctrlr_io_qpair_connect_poll_async(
 		}
 		break;
 	default:
-		// Should not get here in case of errors as polling should have stopped.
+		/* Should not get here in case of errors as polling should have stopped. */
 		assert(false);
 	}
 
-	// Trigger the next polling round.
+	/* Trigger the next polling round. */
 	return 1;
 
-	// Report polling error and request to stop polling.
+	/* Report polling error and request to stop polling. */
 out_error:
 	free(probe_ctx);
 	return rc;
 
-	// Notify the callback and request to stop polling.
+	/* Notify the callback and request to stop polling. */
 out_notify:
 	if (probe_ctx->cb_fn) {
 		probe_ctx->cb_fn(qpair, probe_ctx->cb_arg);

--- a/lib/nvmf/nvmf_internal.h
+++ b/lib/nvmf/nvmf_internal.h
@@ -544,11 +544,12 @@ void nvmf_bdev_ctrlr_zcopy_end(struct spdk_nvmf_request *req, bool commit);
 
 
 static inline void notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
-						void *cb_arg,
-						spdk_nvmf_subsystem_events event)
+		void *cb_arg,
+		spdk_nvmf_subsystem_events event)
 {
-	if (subsystem->nvmf_ss_event_cb)
+	if (subsystem->nvmf_ss_event_cb) {
 		subsystem->nvmf_ss_event_cb(subsystem, cb_arg, event);
+	}
 }
 
 #endif /* __NVMF_INTERNAL_H__ */

--- a/lib/nvmf/subsystem.c
+++ b/lib/nvmf/subsystem.c
@@ -341,10 +341,10 @@ spdk_nvmf_subsystem_create(struct spdk_nvmf_tgt *tgt,
 /* Register a callback function for the subsystem events */
 int
 spdk_nvmf_subsystem_register_for_event(struct spdk_nvmf_subsystem *subsystem,
-						spdk_nvmf_subsystem_event_cb cb)
+				       spdk_nvmf_subsystem_event_cb cb)
 {
 	subsystem->nvmf_ss_event_cb = cb;
-	SPDK_INFOLOG(nvmf, "Subsystem Event callback Registered for %s\n",subsystem->subnqn);
+	SPDK_INFOLOG(nvmf, "Subsystem Event callback Registered for %s\n", subsystem->subnqn);
 	return 0;
 }
 

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1147,6 +1147,26 @@ vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
 }
 
 void
+vbdev_lvol_create_snapshot_ext(struct spdk_lvol *lvol, const char *snapshot_name,
+			       struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+			       spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+{
+	struct spdk_lvol_with_handle_req *req;
+
+	req = calloc(1, sizeof(*req));
+	if (req == NULL) {
+		cb_fn(cb_arg, NULL, -ENOMEM);
+		return;
+	}
+
+	req->cb_fn = cb_fn;
+	req->cb_arg = cb_arg;
+
+	spdk_lvol_create_snapshot_ext(lvol, snapshot_name, xattrs, xattrs_count, _vbdev_lvol_create_cb,
+				      req);
+}
+
+void
 vbdev_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
 			spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -53,6 +53,8 @@ struct lvol_bdev {
 	struct lvol_store_bdev	*lvs_bdev;
 };
 
+struct spdk_xattr_descriptor;
+
 int vbdev_lvs_create(const char *base_bdev_name, const char *name, uint32_t cluster_sz,
 		     enum lvs_clear_method clear_method, spdk_lvs_op_with_handle_complete cb_fn, void *cb_arg);
 int vbdev_lvs_create_with_uuid(const char *base_bdev_name, const char *name, const char *uuid,
@@ -72,6 +74,9 @@ int vbdev_lvol_create_with_uuid(struct spdk_lvol_store *lvs, const char *name, u
 
 void vbdev_lvol_create_snapshot(struct spdk_lvol *lvol, const char *snapshot_name,
 				spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
+void vbdev_lvol_create_snapshot_ext(struct spdk_lvol *lvol, const char *snapshot_name,
+				    struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+				    spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
 void vbdev_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
 			     spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);


### PR DESCRIPTION
This fix enables user to optionally specify xattrs when creating a volume snapshot to make sure the new snapshot has all the attributes set straight when the snapshot is created. A new function “spdk_lvol_create_snapshot_ext()” is introduced to expose such functionality.