### PR TITLE
lvol: support of user-defined attributes for volume clones

### DIFF
--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -897,8 +897,8 @@ int spdk_bdev_read(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
  *   * -ENOMEM - spdk_bdev_io buffer cannot be allocated
  */
 int spdk_bdev_read_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-                              void *buf, uint64_t offset, uint64_t nbytes,
-                              spdk_bdev_io_completion_cb cb, void *cb_arg,
+			      void *buf, uint64_t offset, uint64_t nbytes,
+			      spdk_bdev_io_completion_cb cb, void *cb_arg,
 			      uint32_t ext_io_flags);
 
 /**
@@ -1059,11 +1059,11 @@ int spdk_bdev_readv_blocks(struct spdk_bdev_desc *desc, struct spdk_io_channel *
  *   * -EINVAL - offset_blocks and/or num_blocks are out of range
  *   * -ENOMEM - spdk_bdev_io buffer cannot be allocated
  */
- int spdk_bdev_readv_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-				       struct iovec *iov, int iovcnt,
-				       uint64_t offset_blocks, uint64_t num_blocks,
-				       spdk_bdev_io_completion_cb cb, void *cb_arg,
-				       uint32_t ext_io_flags);
+int spdk_bdev_readv_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
+				      struct iovec *iov, int iovcnt,
+				      uint64_t offset_blocks, uint64_t num_blocks,
+				      spdk_bdev_io_completion_cb cb, void *cb_arg,
+				      uint32_t ext_io_flags);
 
 /**
  * Submit a read request to the bdev on the given channel. This differs from

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -227,6 +227,21 @@ void spdk_lvol_create_snapshot_ext(struct spdk_lvol *lvol, const char *snapshot_
 void spdk_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
 			    spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
+
+/**
+ * Create clone of given snapshot with user-defined attributes.
+ *
+ * \param lvol Handle to lvol snapshot.
+ * \param clone_name Name of created clone.
+ * \param xattrs Optional set of attributes for slone.
+ * \param xattrs_count Number of attributes for clone.
+ * \param cb_fn Completion callback.
+ * \param cb_arg Completion callback custom arguments.
+ */
+void spdk_lvol_create_clone_ext(struct spdk_lvol *lvol, const char *clone_name,
+				struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+				spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
+
 /**
  * Rename lvol with new_name.
  *

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -4606,7 +4606,7 @@ static int
 bdev_read_blocks_with_md(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch, void *buf,
 			 void *md_buf, uint64_t offset_blocks, uint64_t num_blocks,
 			 spdk_bdev_io_completion_cb cb, void *cb_arg,
-                         uint32_t ext_io_flags)
+			 uint32_t ext_io_flags)
 {
 	struct spdk_bdev *bdev = spdk_bdev_desc_get_bdev(desc);
 	struct spdk_bdev_io *bdev_io;
@@ -4649,8 +4649,8 @@ spdk_bdev_read(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
 
 int
 spdk_bdev_read_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-                          void *buf, uint64_t offset, uint64_t nbytes,
-                          spdk_bdev_io_completion_cb cb, void *cb_arg,
+			  void *buf, uint64_t offset, uint64_t nbytes,
+			  spdk_bdev_io_completion_cb cb, void *cb_arg,
 			  uint32_t ext_io_flags)
 {
 	uint64_t offset_blocks, num_blocks;
@@ -4660,7 +4660,8 @@ spdk_bdev_read_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *c
 		return -EINVAL;
 	}
 
-	return spdk_bdev_read_blocks_with_flags(desc, ch, buf, offset_blocks, num_blocks, cb, cb_arg, ext_io_flags);
+	return spdk_bdev_read_blocks_with_flags(desc, ch, buf, offset_blocks, num_blocks, cb, cb_arg,
+						ext_io_flags);
 }
 
 int
@@ -4673,11 +4674,12 @@ spdk_bdev_read_blocks(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
 
 int
 spdk_bdev_read_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-                                 void *buf, uint64_t offset_blocks, uint64_t num_blocks,
-                                 spdk_bdev_io_completion_cb cb, void *cb_arg,
-			         uint32_t ext_io_flags)
+				 void *buf, uint64_t offset_blocks, uint64_t num_blocks,
+				 spdk_bdev_io_completion_cb cb, void *cb_arg,
+				 uint32_t ext_io_flags)
 {
-	return bdev_read_blocks_with_md(desc, ch, buf, NULL, offset_blocks, num_blocks, cb, cb_arg, ext_io_flags);
+	return bdev_read_blocks_with_md(desc, ch, buf, NULL, offset_blocks, num_blocks, cb, cb_arg,
+					ext_io_flags);
 }
 
 int
@@ -4765,11 +4767,12 @@ spdk_bdev_readv_blocks(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
 					 num_blocks, cb, cb_arg, NULL, false, 0);
 }
 
-int spdk_bdev_readv_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
-				      struct iovec *iov, int iovcnt,
-				      uint64_t offset_blocks, uint64_t num_blocks,
-				      spdk_bdev_io_completion_cb cb, void *cb_arg,
-				      uint32_t ext_io_flags)
+int
+spdk_bdev_readv_blocks_with_flags(struct spdk_bdev_desc *desc, struct spdk_io_channel *ch,
+				  struct iovec *iov, int iovcnt,
+				  uint64_t offset_blocks, uint64_t num_blocks,
+				  spdk_bdev_io_completion_cb cb, void *cb_arg,
+				  uint32_t ext_io_flags)
 {
 	return bdev_readv_blocks_with_md(desc, ch, iov, iovcnt, NULL, offset_blocks,
 					 num_blocks, cb, cb_arg, NULL, false, ext_io_flags);

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -5731,7 +5731,8 @@ spdk_blob_get_next_unallocated_io_unit(struct spdk_blob *blob, uint64_t offset)
 	return blob_find_io_unit(blob, offset, false);
 }
 
-uint64_t spdk_blob_calc_used_clusters(struct spdk_blob *blob)
+uint64_t
+spdk_blob_calc_used_clusters(struct spdk_blob *blob)
 {
 	size_t i;
 	uint64_t num;

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -12,6 +12,7 @@
 	spdk_lvol_create_snapshot;
 	spdk_lvol_create_snapshot_ext;
 	spdk_lvol_create_clone;
+	spdk_lvol_create_snapshot_ext;
 	spdk_lvol_rename;
 	spdk_lvol_deletable;
 	spdk_lvol_destroy;

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -436,7 +436,8 @@ struct spdk_nvme_io_qpair_connect_ctx *spdk_nvme_ctrlr_connect_io_qpair_async(
 	return poll_ctx;
 }
 
-int spdk_nvme_ctrlr_io_qpair_connect_poll_async(
+int
+spdk_nvme_ctrlr_io_qpair_connect_poll_async(
 	struct spdk_nvme_qpair *qpair,
 	struct spdk_nvme_io_qpair_connect_ctx *probe_ctx)
 {

--- a/lib/nvmf/nvmf_internal.h
+++ b/lib/nvmf/nvmf_internal.h
@@ -489,9 +489,10 @@ int nvmf_bdev_ctrlr_zcopy_start(struct spdk_bdev *bdev,
 void nvmf_bdev_ctrlr_zcopy_end(struct spdk_nvmf_request *req, bool commit);
 
 
-static inline void notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
-		void *cb_arg,
-		spdk_nvmf_subsystem_events event)
+static inline void
+notify_subsystem_events(struct spdk_nvmf_subsystem *subsystem,
+			void *cb_arg,
+			spdk_nvmf_subsystem_events event)
 {
 	if (subsystem->nvmf_ss_event_cb) {
 		subsystem->nvmf_ss_event_cb(subsystem, cb_arg, event);

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -212,9 +212,11 @@ vbdev_lvs_create(const char *base_bdev_name, const char *name, uint32_t cluster_
 					  cb_fn, cb_arg);
 }
 
-int vbdev_lvs_create_with_uuid(const char *base_bdev_name, const char *name, const char *uuid, uint32_t cluster_sz,
-		     enum lvs_clear_method clear_method, uint32_t num_md_pages_per_cluster_ratio,
-		     spdk_lvs_op_with_handle_complete cb_fn, void *cb_arg)
+int
+vbdev_lvs_create_with_uuid(const char *base_bdev_name, const char *name, const char *uuid,
+			   uint32_t cluster_sz,
+			   enum lvs_clear_method clear_method, uint32_t num_md_pages_per_cluster_ratio,
+			   spdk_lvs_op_with_handle_complete cb_fn, void *cb_arg)
 {
 	struct spdk_bs_dev *bs_dev;
 	struct spdk_lvs_with_handle_req *lvs_req;
@@ -1193,6 +1195,25 @@ vbdev_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
 	req->cb_arg = cb_arg;
 
 	spdk_lvol_create_clone(lvol, clone_name, _vbdev_lvol_create_cb, req);
+}
+
+void
+vbdev_lvol_create_clone_ext(struct spdk_lvol *lvol, const char *clone_name,
+			    struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+			    spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
+{
+	struct spdk_lvol_with_handle_req *req;
+
+	req = calloc(1, sizeof(*req));
+	if (req == NULL) {
+		cb_fn(cb_arg, NULL, -ENOMEM);
+		return;
+	}
+
+	req->cb_fn = cb_fn;
+	req->cb_arg = cb_arg;
+
+	spdk_lvol_create_clone_ext(lvol, clone_name, xattrs, xattrs_count, _vbdev_lvol_create_cb, req);
 }
 
 static void

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -31,9 +31,10 @@ int vbdev_lvs_create(const char *base_bdev_name, const char *name, uint32_t clus
 		     enum lvs_clear_method clear_method, uint32_t num_md_pages_per_cluster_ratio,
 		     spdk_lvs_op_with_handle_complete cb_fn, void *cb_arg);
 
-int vbdev_lvs_create_with_uuid(const char *base_bdev_name, const char *name, const char *uuid, uint32_t cluster_sz,
-		     enum lvs_clear_method clear_method, uint32_t num_md_pages_per_cluster_ratio,
-		     spdk_lvs_op_with_handle_complete cb_fn, void *cb_arg);
+int vbdev_lvs_create_with_uuid(const char *base_bdev_name, const char *name, const char *uuid,
+			       uint32_t cluster_sz,
+			       enum lvs_clear_method clear_method, uint32_t num_md_pages_per_cluster_ratio,
+			       spdk_lvs_op_with_handle_complete cb_fn, void *cb_arg);
 
 void vbdev_lvs_destruct(struct spdk_lvol_store *lvs, spdk_lvs_op_complete cb_fn, void *cb_arg);
 void vbdev_lvs_unload(struct spdk_lvol_store *lvs, spdk_lvs_op_complete cb_fn, void *cb_arg);
@@ -55,6 +56,9 @@ void vbdev_lvol_create_snapshot_ext(struct spdk_lvol *lvol, const char *snapshot
 
 void vbdev_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
 			     spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
+void vbdev_lvol_create_clone_ext(struct spdk_lvol *lvol, const char *clone_name,
+				 struct spdk_xattr_descriptor *xattrs, uint32_t xattrs_count,
+				 spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
 /**
  * \brief Change size of lvol

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -1028,7 +1028,7 @@ cleanup:
 }
 
 SPDK_RPC_REGISTER("bdev_lvol_get_lvstores", rpc_bdev_lvol_get_lvstores, SPDK_RPC_RUNTIME)
-//SPDK_RPC_REGISTER_ALIAS_DEPRECATED(bdev_lvol_get_lvstores, get_lvol_stores)
+/* SPDK_RPC_REGISTER_ALIAS_DEPRECATED(bdev_lvol_get_lvstores, get_lvol_stores) */
 
 struct rpc_bdev_lvol_grow_lvstore {
 	char *uuid;

--- a/module/sock/posix/posix.c
+++ b/module/sock/posix/posix.c
@@ -1077,7 +1077,8 @@ retry:
 		}
 	}
 
-	sock = posix_sock_alloc(fd, &impl_opts, enable_zcopy_user_opts && enable_zcopy_impl_opts, !conn_inprogress);
+	sock = posix_sock_alloc(fd, &impl_opts, enable_zcopy_user_opts &&
+				enable_zcopy_impl_opts, !conn_inprogress);
 	if (sock == NULL) {
 		SPDK_ERRLOG("sock allocation failed\n");
 		SSL_free(ssl);
@@ -1311,8 +1312,7 @@ _sock_check_zcopy(struct spdk_sock *sock)
 }
 #endif
 
-static int
-posix_sock_connect_poll(struct spdk_posix_sock *sock);
+static int posix_sock_connect_poll(struct spdk_posix_sock *sock);
 
 static int
 _sock_flush(struct spdk_sock *sock)


### PR DESCRIPTION
This fix enables user to optionally specify xattrs when creating a volume clone to make sure the new clone has all the attributes set straight when the clone is created. A new function “spdk_lvol_create_clone_ext()” is introduced to expose such functionality.