### PR TITLE
feat(blob): report space allocated by blob ancestors

### DIFF
--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -442,6 +442,12 @@ uint64_t spdk_blob_get_num_io_units(struct spdk_blob *blob);
 uint64_t spdk_blob_get_num_clusters(struct spdk_blob *blob);
 
 /**
+ * Get the number of clusters allocated by all ancestors of this blob.
+ */
+int spdk_blob_get_num_clusters_ancestors(struct spdk_blob_store *bs, struct spdk_blob *blob,
+		uint64_t *num_clusters);
+
+/**
  * Get next allocated io_unit
  *
  * Starting at 'offset' io_units into the blob, returns the offset of

--- a/lib/bdev/spdk_bdev.map
+++ b/lib/bdev/spdk_bdev.map
@@ -60,6 +60,7 @@
 	spdk_bdev_read_blocks_with_md;
 	spdk_bdev_readv;
 	spdk_bdev_readv_blocks;
+	spdk_bdev_readv_blocks_with_flags;
 	spdk_bdev_readv_blocks_with_md;
 	spdk_bdev_write;
 	spdk_bdev_write_blocks;

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -40,6 +40,7 @@ static int blob_remove_xattr(struct spdk_blob *blob, const char *name, bool inte
 
 static void blob_write_extent_page(struct spdk_blob *blob, uint32_t extent, uint64_t cluster_num,
 				   struct spdk_blob_md_page *page, spdk_blob_op_complete cb_fn, void *cb_arg);
+static struct spdk_blob *blob_lookup(struct spdk_blob_store *bs, spdk_blob_id blobid);
 
 static int
 blob_id_cmp(struct spdk_blob *blob1, struct spdk_blob *blob2)
@@ -194,6 +195,30 @@ blob_xattrs_init(struct spdk_blob_xattr_opts *xattrs)
 	xattrs->names = NULL;
 	xattrs->ctx = NULL;
 	xattrs->get_value = NULL;
+}
+
+int
+spdk_blob_get_num_clusters_ancestors(struct spdk_blob_store *bs, struct spdk_blob *blob,
+				     uint64_t *num_clusters)
+{
+	uint64_t clusters = 0;
+	struct spdk_blob *b = blob;
+
+	while (b->parent_id != SPDK_BLOBID_INVALID) {
+		spdk_blob_id blob_id = b->parent_id;
+
+		b = blob_lookup(bs, blob_id);
+
+		if (b == NULL) {
+			SPDK_ERRLOG("Can't lookup parent blob with ID %ld", blob_id);
+			return -ENXIO;
+		}
+
+		clusters += spdk_blob_calc_used_clusters(b);
+	}
+
+	*num_clusters = clusters;
+	return 0;
 }
 
 void

--- a/lib/blob/spdk_blob.map
+++ b/lib/blob/spdk_blob.map
@@ -16,6 +16,7 @@
 	spdk_bs_free_cluster_count;
 	spdk_bs_total_data_cluster_count;
 	spdk_bs_grow;
+	spdk_blob_calc_used_clusters;
 	spdk_blob_get_id;
 	spdk_blob_get_num_pages;
 	spdk_blob_get_num_io_units;
@@ -27,6 +28,7 @@
 	spdk_bs_create_blob;
 	spdk_bs_create_snapshot;
 	spdk_bs_create_clone;
+	spdk_blob_get_ancestor_usage;
 	spdk_blob_get_clones;
 	spdk_blob_get_parent_snapshot;
 	spdk_blob_is_read_only;

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -12,6 +12,7 @@
 	spdk_lvol_create_snapshot;
 	spdk_lvol_create_snapshot_ext;
 	spdk_lvol_create_clone;
+	spdk_lvol_create_clone_ext;
 	spdk_lvol_create_snapshot_ext;
 	spdk_lvol_rename;
 	spdk_lvol_deletable;

--- a/lib/nvme/spdk_nvme.map
+++ b/lib/nvme/spdk_nvme.map
@@ -80,6 +80,7 @@
 	spdk_nvme_ctrlr_cmd_admin_raw;
 	spdk_nvme_ctrlr_process_admin_completions;
 	spdk_nvme_ctrlr_get_ns;
+	spdk_nvme_ctrlr_io_qpair_connect_poll_async;
 	spdk_nvme_ctrlr_cmd_get_log_page;
 	spdk_nvme_ctrlr_cmd_get_log_page_ext;
 	spdk_nvme_ctrlr_cmd_abort;


### PR DESCRIPTION
This fix introduces a new API function spdk_blob_get_num_clusters_ancestors() which allows obtaining amount of clusters allocated by all snapshots of the blob.