### PR TITLE
nvme: replace ZNS identify data in place during namespace update

### DIFF
--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -3076,7 +3076,6 @@ nvme_ctrlr_update_namespaces(struct spdk_nvme_ctrlr *ctrlr)
 	for (nsid = spdk_nvme_ctrlr_get_first_active_ns(ctrlr);
 	     nsid != 0; nsid = spdk_nvme_ctrlr_get_next_active_ns(ctrlr, nsid)) {
 		ns = spdk_nvme_ctrlr_get_ns(ctrlr, nsid);
-		nvme_ns_destruct(ns);
 		nvme_ns_construct(ns, nsid, ctrlr);
 	}
 }


### PR DESCRIPTION
This is a workaround for #3126. The issue is intermittent due to perf app error handling, see next patch addressing it.

During nvmf_lvol test logical volume on NVMe-oF target is resized, which sends AER to the initiator perf application. While handling Namespace Attribute Changed, nvme_ctrlr_update_namespaces() destroys and constructs all active namespaces.
This behavior changed in patch:
(6fb6fda) nvme: Fix ZNS assert for NS_ATTR_CHANGED AEN

With patch above a race condition was made more prevalent. During the NS update, all perf threads still issue I/O based on fields in spdk_nvme_ns - see _nvme_ns_cmd_rw(). Since NS update destroys it briefly (sets fields to 0), some of the I/O fails.

This patch works around this issue by proposing alternative approach to filling out ZNS fields during NS update.
Most of the nvme_ns_construct(), already replaced the fields that are zeroed out in nvme_ns_destruct(). ZNS fields were the exception, so remove the troublesome assumption that nsdata_zns is not allocated. Free ZNS specific data first, then only assign it to ns if it has been filled out.

NOTE: More holistic approach might be needed to address the core of the race condition between ns update and I/O threads using ns fields.


Change-Id: I227fbba6b79bb1c705702a8d473a9705b83e7783
Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/21144
Community-CI: Mellanox Build Bot
Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
Reviewed-by: Jim Harris <jim.harris@samsung.com>
Reviewed-by: Mateusz Kozlowski <mateusz.kozlowski@solidigm.com>