### PR TITLE
chore: unwritten block check from current blob during read

### DIFF
--- a/include/spdk/nvme_spec.h
+++ b/include/spdk/nvme_spec.h
@@ -4303,6 +4303,9 @@ SPDK_STATIC_ASSERT(sizeof(struct spdk_nvme_ns_streams_status) == 131072, "Incorr
 /** When set, reading of unwritten or deallocated block of a thin-provisioned device will fail
  * with SPDK_NVME_SC_DEALLOCATED_OR_UNWRITTEN_BLOCK */
 #define SPDK_NVME_IO_FLAGS_UNWRITTEN_READ_FAIL (4U << 20)
+/** When set, check for allocated blocks from current blob, rather checking from
+ * complete blob chain while doing read */
+#define SPDK_NVME_IO_FLAG_CURRENT_UNWRITTEN_READ_FAIL (4U << 19)
 /** Zone append specific, determines the contents of the reference tag written to the media */
 #define SPDK_NVME_IO_FLAGS_ZONE_APPEND_PIREMAP (1U << 25)
 /** Enable protection information checking of the Logical Block Reference Tag field */

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -3274,6 +3274,10 @@ blob_request_submit_rw_iov(struct spdk_blob *blob, struct spdk_io_channel *_chan
 		if (read) {
 			spdk_bs_sequence_t *seq;
 
+			if (!is_allocated && (ext_io_flags & SPDK_NVME_IO_FLAG_CURRENT_UNWRITTEN_READ_FAIL)) {
+				cb_fn(cb_arg, -ETXTBSY);
+				return;
+			}
 			if (!is_allocated && (ext_io_flags & SPDK_NVME_IO_FLAGS_UNWRITTEN_READ_FAIL)) {
 				is_allocated = blob_ancestor_calc_lba_and_lba_count(blob, offset, length, &lba, &lba_count);
 				if (!is_allocated) {


### PR DESCRIPTION
- A new flag is added which will be set in the dataplane while doing read in snapshot rebuild flow.
- The existing flag `SPDK_NVME_IO_FLAGS_UNWRITTEN_READ_FAIL` will check for unwritten blocks from current blob and it's ancestor blobs.
- The new flag `SPDK_NVME_IO_FLAG_CURRENT_UNWRITTEN_READ_FAIL` will check for unwritten blocks from current blob only.
- During snapshot rebuild, this new flag can be set to read only the current snapshot data rather checking for ancestor data.
- After complete snapshot chain is rebuild when the last replica data is rebuild, this flag can be used to avoid unnecessary checks on ancestors.