### PR TITLE
nvmf: increase QID retry period from 100us to 1ms

### DIFF
--- a/lib/nvmf/ctrlr.c
+++ b/lib/nvmf/ctrlr.c
@@ -31,7 +31,7 @@
 
 #define NVMF_CTRLR_RESET_SHN_TIMEOUT_IN_MS	(NVMF_CC_RESET_SHN_TIMEOUT_IN_MS + 5000)
 
-#define DUPLICATE_QID_RETRY_US 100
+#define DUPLICATE_QID_RETRY_US 1000
 
 /*
  * Report the SPDK version as the firmware revision.


### PR DESCRIPTION
The original 100us value was picked out of thin air, since we didn't have a good repro vehicle. Since we've seen this at least once more since the original patch was merged, increase the value to 1ms. There is no harm waiting a bit longer before responding to the CONNECT in this very rare case.

Fixes issue #2955.


Change-Id: Icbe97c179c96deea93f7097f8443362e7873f4bb
Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/21383
Community-CI: Mellanox Build Bot
Reviewed-by: Aleksey Marchuk <alexeymar@nvidia.com>
Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>