### PR TITLE
handle IO on a resized blob

### DIFF
--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -231,6 +231,10 @@ struct spdk_bs_dev {
 	struct spdk_bdev *(*get_base_bdev)(struct spdk_bs_dev *dev);
 
 	bool (*is_zeroes)(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_count);
+	/* Is the lba range we are looking for valid or not for this bs_dev. Used to
+	 * check if we can safely reference the bs_dev during CoW or perhaps even
+	 * during read. */
+	bool (*is_range_valid)(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_count);
 
 	/* Translate blob lba to lba on the underlying bdev.
 	 * This operation recurses down the whole chain of bs_dev's.

--- a/lib/blob/blob_bs_dev.c
+++ b/lib/blob/blob_bs_dev.c
@@ -7,6 +7,7 @@
 #include "spdk/stdinc.h"
 #include "spdk/blob.h"
 #include "spdk/log.h"
+#include "spdk/likely.h"
 #include "blobstore.h"
 
 static void
@@ -66,10 +67,55 @@ blob_bs_dev_read_cpl(void *cb_arg, int bserrno)
 }
 
 static inline void
+zero_trailing_bytes(struct spdk_blob_bs_dev *b, struct iovec *iov, int iovcnt,
+		    uint64_t lba, uint32_t *lba_count)
+{
+	uint32_t zero_lba_count;
+	uint64_t zero_bytes, zero_len;
+	uint64_t payload_bytes;
+	uint64_t valid_bytes;
+	void *zero_start;
+	struct iovec *i;
+
+	if (spdk_likely(lba + *lba_count <= b->bs_dev.blockcnt)) {
+		return;
+	}
+
+	/* Figure out how many bytes in the payload will need to be zeroed. */
+	zero_lba_count = spdk_min(*lba_count, lba + *lba_count - b->bs_dev.blockcnt);
+	zero_bytes = zero_lba_count * b->bs_dev.blocklen;
+
+	payload_bytes = *lba_count * b->bs_dev.blocklen;
+	valid_bytes = payload_bytes - zero_bytes;
+
+	i = iov;
+	while (zero_bytes > 0) {
+		if (i->iov_len > valid_bytes) {
+			zero_start = i->iov_base + valid_bytes;
+			zero_len = spdk_min(payload_bytes, i->iov_len - valid_bytes);
+			memset(zero_start, 0, zero_bytes);
+			valid_bytes = 0;
+			zero_bytes -= zero_len;
+		}
+		valid_bytes -= spdk_min(valid_bytes, i->iov_len);
+		payload_bytes -= spdk_min(payload_bytes, i->iov_len);
+		i++;
+	}
+
+	*lba_count -= zero_lba_count;
+}
+
+static inline void
 blob_bs_dev_read(struct spdk_bs_dev *dev, struct spdk_io_channel *channel, void *payload,
 		 uint64_t lba, uint32_t lba_count, struct spdk_bs_dev_cb_args *cb_args)
 {
 	struct spdk_blob_bs_dev *b = (struct spdk_blob_bs_dev *)dev;
+	struct iovec iov;
+
+	iov.iov_base = payload;
+	iov.iov_len = lba_count * b->bs_dev.blocklen;
+	/* The backing blob may be smaller than this blob, so zero any trailing bytes. */
+	zero_trailing_bytes(b, &iov, 1, lba, &lba_count);
 
 	spdk_blob_io_read(b->blob, channel, payload, lba, lba_count,
 			  blob_bs_dev_read_cpl, cb_args);
@@ -82,6 +128,9 @@ blob_bs_dev_readv(struct spdk_bs_dev *dev, struct spdk_io_channel *channel,
 {
 	struct spdk_blob_bs_dev *b = (struct spdk_blob_bs_dev *)dev;
 
+	/* The backing blob may be smaller than this blob, so zero any trailing bytes. */
+	zero_trailing_bytes(b, iov, iovcnt, lba, &lba_count);
+
 	spdk_blob_io_readv(b->blob, channel, iov, iovcnt, lba, lba_count, 0,
 			   blob_bs_dev_read_cpl, cb_args);
 }
@@ -93,6 +142,9 @@ blob_bs_dev_readv_ext(struct spdk_bs_dev *dev, struct spdk_io_channel *channel,
 		      struct spdk_blob_ext_io_opts *ext_opts)
 {
 	struct spdk_blob_bs_dev *b = (struct spdk_blob_bs_dev *)dev;
+
+	/* The backing blob may be smaller than this blob, so zero any trailing bytes. */
+	zero_trailing_bytes(b, iov, iovcnt, lba, &lba_count);
 
 	spdk_blob_io_readv_ext(b->blob, channel, iov, iovcnt, lba, lba_count, 0,
 			       blob_bs_dev_read_cpl, cb_args, ext_opts);
@@ -134,6 +186,33 @@ blob_bs_is_zeroes(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_count)
 	return blob->back_bs_dev->is_zeroes(blob->back_bs_dev,
 					    bs_io_unit_to_back_dev_lba(blob, lba),
 					    bs_io_unit_to_back_dev_lba(blob, lba_count));
+}
+
+static bool
+blob_bs_is_range_valid(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_count)
+{
+	struct spdk_blob_bs_dev *b = (struct spdk_blob_bs_dev *)dev;
+	struct spdk_blob *blob = b->blob;
+	uint64_t	page;
+	uint64_t	pages_per_cluster;
+
+	/* The lba here is supposed to be the first lba of cluster. lba_count
+	 * will typically be fixed e.g. 8192 for 4MiB cluster. */
+	assert(lba_count == blob->bs->cluster_sz / dev->blocklen);
+	assert(lba % lba_count == 0);
+
+	pages_per_cluster = blob->bs->pages_per_cluster;
+	page = bs_io_unit_to_page(blob->bs, lba);
+
+	/* A blob will either have:
+	* - no backing bs_bdev (normal thick blob), or
+	* - zeroes backing bs_bdev (thin provisioned blob), or
+	* - blob backing bs_bdev (e.g snapshot)
+	* It may be possible that backing bs_bdev has lesser number of clusters
+	* than the child lvol blob because lvol blob has been expanded after
+	* taking snapshot. In such a case, page will be outside the cluster page
+	* range of the backing dev. Always return true for zeroes backing bdev. */
+	return page < blob->active.num_clusters * pages_per_cluster;
 }
 
 static bool
@@ -187,6 +266,7 @@ bs_create_blob_bs_dev(struct spdk_blob *blob)
 	b->bs_dev.write_zeroes = blob_bs_dev_write_zeroes;
 	b->bs_dev.unmap = blob_bs_dev_unmap;
 	b->bs_dev.is_zeroes = blob_bs_is_zeroes;
+	b->bs_dev.is_range_valid = blob_bs_is_range_valid;
 	b->bs_dev.translate_lba = blob_bs_translate_lba;
 	b->bs_dev.is_degraded = blob_bs_is_degraded;
 	b->blob = blob;

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -2665,6 +2665,7 @@ bs_allocate_and_copy_cluster(struct spdk_blob *blob,
 	uint32_t cluster_number;
 	bool is_zeroes;
 	bool can_copy;
+	bool is_valid_range;
 	uint64_t copy_src_lba;
 	int rc;
 
@@ -2697,9 +2698,18 @@ bs_allocate_and_copy_cluster(struct spdk_blob *blob,
 	ctx->page = cluster_start_page;
 	ctx->new_cluster_page = ch->new_cluster_page;
 	memset(ctx->new_cluster_page, 0, SPDK_BS_PAGE_SIZE);
-	can_copy = blob_can_copy(blob, cluster_start_page, &copy_src_lba);
 
-	is_zeroes = blob->back_bs_dev->is_zeroes(blob->back_bs_dev,
+	/* Check if the cluster that we intend to do CoW for is valid for
+	 * the backing dev. For zeroes backing dev, it'll be always valid.
+	 * For other backing dev e.g. a snapshot, it could be invalid if
+	 * the blob has been resized after snapshot was taken. */
+	is_valid_range = blob->back_bs_dev->is_range_valid(blob->back_bs_dev,
+			 bs_dev_page_to_lba(blob->back_bs_dev, cluster_start_page),
+			 bs_dev_byte_to_lba(blob->back_bs_dev, blob->bs->cluster_sz));
+
+	can_copy = is_valid_range && blob_can_copy(blob, cluster_start_page, &copy_src_lba);
+
+	is_zeroes = is_valid_range && blob->back_bs_dev->is_zeroes(blob->back_bs_dev,
 			bs_dev_page_to_lba(blob->back_bs_dev, cluster_start_page),
 			bs_dev_byte_to_lba(blob->back_bs_dev, blob->bs->cluster_sz));
 	if (blob->parent_id != SPDK_BLOBID_INVALID && !is_zeroes && !can_copy) {

--- a/lib/blob/zeroes.c
+++ b/lib/blob/zeroes.c
@@ -125,6 +125,12 @@ zeroes_is_zeroes(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_count)
 }
 
 static bool
+zeroes_is_range_valid(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_count)
+{
+	return true;
+}
+
+static bool
 zeroes_translate_lba(struct spdk_bs_dev *dev, uint64_t lba, uint64_t *base_lba)
 {
 	return false;
@@ -145,6 +151,7 @@ static struct spdk_bs_dev g_zeroes_bs_dev = {
 	.write_zeroes = zeroes_write_zeroes,
 	.unmap = zeroes_unmap,
 	.is_zeroes = zeroes_is_zeroes,
+	.is_range_valid = zeroes_is_range_valid,
 	.translate_lba = zeroes_translate_lba,
 };
 

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -2117,6 +2117,13 @@ bs_dev_degraded_is_zeroes(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_co
 	return false;
 }
 
+static bool
+bs_dev_degraded_is_range_valid(struct spdk_bs_dev *dev, uint64_t lba, uint64_t lba_count)
+{
+	assert(false);
+	return false;
+}
+
 static struct spdk_io_channel *
 bs_dev_degraded_create_channel(struct spdk_bs_dev *bs_dev)
 {
@@ -2149,6 +2156,7 @@ static struct spdk_bs_dev bs_dev_degraded = {
 	.readv = bs_dev_degraded_readv,
 	.readv_ext = bs_dev_degraded_readv_ext,
 	.is_zeroes = bs_dev_degraded_is_zeroes,
+	.is_range_valid = bs_dev_degraded_is_range_valid,
 	.is_degraded = bs_dev_degraded_is_degraded,
 	/* Make the device as large as possible without risk of uint64 overflow. */
 	.blockcnt = UINT64_MAX / 512,

--- a/test/unit/lib/blob/blob.c/blob_ut.c
+++ b/test/unit/lib/blob/blob.c/blob_ut.c
@@ -8578,6 +8578,219 @@ blob_is_degraded(void)
 	g_blob->back_bs_dev = NULL;
 }
 
+/* Resize a blob which is a clone created from snapshot. Verify read/writes to
+ * expanded clone blob. Then inflate the clone blob. */
+static void
+blob_clone_resize(void)
+{
+	struct spdk_blob_store *bs = g_bs;
+	struct spdk_blob_opts opts;
+	struct spdk_blob *blob, *clone;
+	spdk_blob_id blobid, cloneid, snapshotid;
+	uint64_t pages_per_cluster;
+	uint8_t payload_read[bs->dev->blocklen];
+	uint8_t payload_write[bs->dev->blocklen];
+	struct spdk_io_channel *channel;
+	uint64_t free_clusters;
+
+	channel = spdk_bs_alloc_io_channel(bs);
+	SPDK_CU_ASSERT_FATAL(channel != NULL);
+
+	pages_per_cluster = spdk_bs_get_cluster_size(bs) / spdk_bs_get_page_size(bs);
+
+	/* Create blob with 10 clusters */
+	ut_spdk_blob_opts_init(&opts);
+	opts.num_clusters = 10;
+
+	blob = ut_blob_create_and_open(bs, &opts);
+	blobid = spdk_blob_get_id(blob);
+	CU_ASSERT(spdk_blob_get_num_clusters(blob) == 10);
+
+	/* Create snapshot */
+	spdk_bs_create_snapshot(bs, blobid, NULL, blob_op_with_id_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(g_blobid != SPDK_BLOBID_INVALID);
+	snapshotid = g_blobid;
+
+	spdk_bs_create_clone(bs, snapshotid, NULL, blob_op_with_id_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(g_blobid != SPDK_BLOBID_INVALID);
+	cloneid = g_blobid;
+
+	spdk_bs_open_blob(bs, cloneid, blob_op_with_handle_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_blob != NULL);
+	clone = g_blob;
+	CU_ASSERT(spdk_blob_get_num_clusters(clone) == 10);
+
+	g_bserrno = -1;
+	spdk_blob_resize(clone, 20, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(spdk_blob_get_num_clusters(clone) == 20);
+
+	/* Write and read from pre-resize ranges */
+	g_bserrno = -1;
+	memset(payload_write, 0xE5, sizeof(payload_write));
+	spdk_blob_io_write(clone, channel, payload_write, 5 * pages_per_cluster, 1, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+
+	g_bserrno = -1;
+	memset(payload_read, 0x00, sizeof(payload_read));
+	spdk_blob_io_read(clone, channel, payload_read, 5 * pages_per_cluster, 1, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(memcmp(payload_write, payload_read, 4096) == 0);
+
+	/* Write and read from post-resize ranges */
+	g_bserrno = -1;
+	memset(payload_write, 0xE5, sizeof(payload_write));
+	spdk_blob_io_write(clone, channel, payload_write, 15 * pages_per_cluster, 1, blob_op_complete,
+			   NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+
+	g_bserrno = -1;
+	memset(payload_read, 0x00, sizeof(payload_read));
+	spdk_blob_io_read(clone, channel, payload_read, 15 * pages_per_cluster, 1, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(memcmp(payload_write, payload_read, bs->dev->blocklen) == 0);
+
+	/* Now do full blob inflation of the resized blob/clone. */
+	free_clusters = spdk_bs_free_cluster_count(bs);
+	spdk_bs_inflate_blob(bs, channel, cloneid, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	/* We wrote to 2 clusters earlier, all remaining 18 clusters in
+	 * blob should get allocated after inflation */
+	CU_ASSERT(spdk_bs_free_cluster_count(bs) == free_clusters - 18);
+
+	spdk_blob_close(clone, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+
+	ut_blob_close_and_delete(bs, blob);
+
+	spdk_bs_free_io_channel(channel);
+}
+
+
+static void
+blob_esnap_clone_resize(void)
+{
+	struct spdk_bs_dev *dev;
+	struct spdk_blob_store *bs;
+	struct spdk_bs_opts bsopts;
+	struct spdk_blob_opts opts;
+	struct ut_esnap_opts esnap_opts;
+	struct spdk_blob *blob;
+	uint32_t block, esnap_blksz = 512, bs_blksz = 512;
+	const uint32_t cluster_sz = 16 * 1024;
+	const uint64_t esnap_num_clusters = 4;
+	const uint32_t esnap_sz = cluster_sz * esnap_num_clusters;
+	const uint64_t esnap_num_blocks = esnap_sz / esnap_blksz;
+	uint64_t blob_num_blocks = esnap_sz / bs_blksz;
+	struct spdk_io_channel *bs_ch;
+
+	spdk_bs_opts_init(&bsopts, sizeof(bsopts));
+	bsopts.cluster_sz = cluster_sz;
+	bsopts.esnap_bs_dev_create = ut_esnap_create;
+	/* Create device with desired block size */
+	dev = init_dev();
+	dev->blocklen = bs_blksz;
+	dev->blockcnt = DEV_BUFFER_SIZE / dev->blocklen;
+	/* Initialize a new blob store */
+	spdk_bs_init(dev, &bsopts, bs_op_with_handle_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	SPDK_CU_ASSERT_FATAL(g_bs != NULL);
+	SPDK_CU_ASSERT_FATAL(g_bs->io_unit_size == bs_blksz);
+	bs = g_bs;
+
+	bs_ch = spdk_bs_alloc_io_channel(bs);
+	SPDK_CU_ASSERT_FATAL(bs_ch != NULL);
+
+	/* Create and open the esnap clone  */
+	ut_spdk_blob_opts_init(&opts);
+	ut_esnap_opts_init(esnap_blksz, esnap_num_blocks, __func__, NULL, &esnap_opts);
+	opts.esnap_id = &esnap_opts;
+	opts.esnap_id_len = sizeof(esnap_opts);
+	opts.num_clusters = esnap_num_clusters;
+	blob = ut_blob_create_and_open(bs, &opts);
+	SPDK_CU_ASSERT_FATAL(blob != NULL);
+
+	g_bserrno = -1;
+	spdk_blob_resize(blob, esnap_num_clusters * 2, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	CU_ASSERT(spdk_blob_get_num_clusters(blob) == esnap_num_clusters * 2);
+
+	/* Write one blob block at a time; verify that the surrounding blocks are OK */
+	blob_num_blocks = (spdk_blob_get_num_clusters(blob) * cluster_sz) / bs_blksz;
+	for (block = 0; block < blob_num_blocks; block++) {
+		char buf[bs_blksz];
+		union ut_word word;
+		word.f.blob_id = 0xfedcba90;
+		word.f.lba = block;
+		ut_memset8(buf, word.num, bs_blksz);
+		spdk_blob_io_write(blob, bs_ch, buf, block, 1, bs_op_complete, NULL);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+		if (g_bserrno != 0) {
+			break;
+		}
+		/* Read and verify the block before the current block */
+		if (block != 0) {
+			spdk_blob_io_read(blob, bs_ch, buf, block - 1, 1, bs_op_complete, NULL);
+			poll_threads();
+			CU_ASSERT(g_bserrno == 0);
+			if (g_bserrno != 0) {
+				break;
+			}
+			CU_ASSERT(ut_esnap_content_is_correct(buf, bs_blksz, word.f.blob_id,
+							      (block - 1) * bs_blksz, bs_blksz));
+		}
+		/* Read and verify the current block */
+		spdk_blob_io_read(blob, bs_ch, buf, block, 1, bs_op_complete, NULL);
+		poll_threads();
+		CU_ASSERT(g_bserrno == 0);
+		if (g_bserrno != 0) {
+			break;
+		}
+		CU_ASSERT(ut_esnap_content_is_correct(buf, bs_blksz, word.f.blob_id,
+						      block * bs_blksz, bs_blksz));
+		/* Check the block that follows */
+		if (block + 1 < blob_num_blocks) {
+			g_bserrno = 0xbad;
+			spdk_blob_io_read(blob, bs_ch, buf, block + 1, 1, bs_op_complete, NULL);
+			poll_threads();
+			CU_ASSERT(g_bserrno == 0);
+			if (g_bserrno != 0) {
+				break;
+			}
+			CU_ASSERT(ut_esnap_content_is_correct(buf, bs_blksz, blob->id,
+							      (block + 1) * bs_blksz,
+							      esnap_blksz));
+		}
+	}
+	/* Clean up */
+	spdk_bs_free_io_channel(bs_ch);
+	g_bserrno = 0xbad;
+	spdk_blob_close(blob, blob_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	spdk_bs_unload(g_bs, bs_op_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno == 0);
+	g_bs = NULL;
+	memset(g_dev_buffer, 0, DEV_BUFFER_SIZE);
+}
+
 static void
 suite_bs_setup(void)
 {
@@ -8790,6 +9003,8 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite_esnap_bs, blob_esnap_clone_reload);
 	CU_ADD_TEST(suite_esnap_bs, blob_esnap_hotplug);
 	CU_ADD_TEST(suite_blob, blob_is_degraded);
+	CU_ADD_TEST(suite_bs, blob_clone_resize);
+	CU_ADD_TEST(suite, blob_esnap_clone_resize);
 
 	allocate_threads(2);
 	set_thread(0);


### PR DESCRIPTION
When a blob is resized and is backed by a another blob like a snapshot, then the resized blob has more number of clusters compared to backing device. Since the blob is thin, either originally or as a result of creating snapshot, the IOs to the new cluster ranges fail as there is no cluster to be looked at in the backing. This patch introduces mechanism to handle reads by zeroeing out the payload which is trailing beyond cluster range, and handle writes by validating backing dev cluster range during copy-on-write.

Change-Id: Ib204b922819775396e53ffb718e8230ebf8fa46b