### PR TITLE
fix: handle lba range validity on ancestors with smaller sizes

### DIFF
--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -2798,6 +2798,14 @@ blob_ancestor_calc_lba_and_lba_count(struct spdk_blob *blob, uint64_t io_unit, u
 	}
 	*lba_count = length;
 	while (blob->parent_id != SPDK_BLOBID_INVALID) {
+		uint32_t cluster_start_page = bs_io_unit_to_cluster_start(blob, io_unit);
+		bool is_valid_range = blob->back_bs_dev->is_range_valid(blob->back_bs_dev,
+				      bs_dev_page_to_lba(blob->back_bs_dev, cluster_start_page),
+				      bs_dev_byte_to_lba(blob->back_bs_dev, blob->bs->cluster_sz));
+		if (!is_valid_range) {
+			goto error;
+		}
+
 		spdk_blob_id blob_id = blob->parent_id;
 		blob = blob_lookup(blob->bs, blob_id);
 		if (blob == NULL) {


### PR DESCRIPTION
- Do valid cluster range check while handling SPDK_NVME_IO_FLAGS_UNWRITTEN_READ_FAIL
- While traversing back bs_devs during zeroes check or translate, do the range valid check for every bs_dev.