### PR TITLE
Fix bdev max rw size calculation

### DIFF
--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -7795,15 +7795,15 @@ bdev_register(struct spdk_bdev *bdev)
 		}
 	}
 
-	spdk_iobuf_get_opts(&iobuf_opts, sizeof(iobuf_opts));
-	if (spdk_bdev_get_buf_align(bdev) > 1) {
-		bdev->max_rw_size = spdk_min(bdev->max_rw_size ? bdev->max_rw_size : UINT32_MAX,
-					     iobuf_opts.large_bufsize / bdev->blocklen);
-	}
-
 	/* If the user didn't specify a write unit size, set it to one. */
 	if (bdev->write_unit_size == 0) {
 		bdev->write_unit_size = 1;
+	}
+
+	spdk_iobuf_get_opts(&iobuf_opts, sizeof(iobuf_opts));
+	if (spdk_bdev_get_buf_align(bdev) > 1) {
+		bdev->max_rw_size = spdk_min(bdev->max_rw_size ? bdev->max_rw_size : UINT32_MAX,
+					     bdev_get_max_write(bdev, iobuf_opts.large_bufsize));
 	}
 
 	/* Set ACWU value to the write unit size if bdev module did not set it (does not support it natively) */


### PR DESCRIPTION
max write size calculation need to account aligned length and the blocklen with metadata as done via bdev_get_max_write. This otherwise fails during bdev_io_get_buf for bounce buffer where max length returned by bdev_io_get_max_buf_len breaches the iobuf_large length.

Change-Id: I0e2ee2cfa80f0617f8b1379315b9dba2459d2c71

## Note
The corresponding fix on upstream SPDK is approved here: https://review.spdk.io/c/spdk/spdk/+/25665 
The merge there might take time and hence cherry-picked locally from that branch already.