### PR TITLE
bdev/crypto: support resize of base bdev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/module/bdev/crypto/vbdev_crypto.c
+++ b/module/bdev/crypto/vbdev_crypto.c
@@ -701,6 +701,18 @@ vbdev_crypto_base_bdev_hotremove_cb(struct spdk_bdev *bdev_find)
 	}
 }
 
+static void
+vbdev_crypto_base_bdev_resize_cb(struct spdk_bdev *bdev_find)
+{
+	struct vbdev_crypto *crypto_bdev;
+
+	TAILQ_FOREACH(crypto_bdev, &g_vbdev_crypto, link) {
+		if (bdev_find == crypto_bdev->base_bdev) {
+			spdk_bdev_notify_blockcnt_change(&crypto_bdev->crypto_bdev, bdev_find->blockcnt);
+		}
+	}
+}
+
 /* Called when the underlying base bdev triggers asynchronous event such as bdev removal. */
 static void
 vbdev_crypto_base_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
@@ -709,6 +721,9 @@ vbdev_crypto_base_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev
 	switch (type) {
 	case SPDK_BDEV_EVENT_REMOVE:
 		vbdev_crypto_base_bdev_hotremove_cb(bdev);
+		break;
+	case SPDK_BDEV_EVENT_RESIZE:
+		vbdev_crypto_base_bdev_resize_cb(bdev);
 		break;
 	default:
 		SPDK_NOTICELOG("Unsupported bdev event: type %d\n", type);

--- a/test/unit/lib/bdev/crypto.c/crypto_ut.c
+++ b/test/unit/lib/bdev/crypto.c/crypto_ut.c
@@ -77,6 +77,7 @@ DEFINE_STUB(spdk_bdev_get_memory_domains, int,
 DEFINE_STUB(spdk_accel_get_memory_domain, struct spdk_memory_domain *, (void), (void *)0xdeadbeef);
 DEFINE_STUB(spdk_accel_get_buf_align, uint8_t,
 	    (enum spdk_accel_opcode opcode, const struct spdk_accel_operation_exec_ctx *ctx), 0);
+DEFINE_STUB(spdk_bdev_notify_blockcnt_change, int, (struct spdk_bdev *bdev, uint64_t size), 0);
 
 /* global vars and setup/cleanup functions used for all test functions */
 struct spdk_bdev_io *g_base_io;


### PR DESCRIPTION
This is present in the latest release v25.05. We will need this changes for growing crypto vbdev when base aio bdev is resized.