### PR TITLE
blob: use uint64_t for cluster start page index

### DIFF
--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -2830,7 +2830,7 @@ blob_write_copy(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 }
 
 static bool
-blob_can_copy(struct spdk_blob *blob, uint32_t cluster_start_page, uint64_t *base_lba)
+blob_can_copy(struct spdk_blob *blob, uint64_t cluster_start_page, uint64_t *base_lba)
 {
 	uint64_t lba = bs_dev_page_to_lba(blob->back_bs_dev, cluster_start_page);
 
@@ -2859,7 +2859,7 @@ bs_allocate_and_copy_cluster(struct spdk_blob *blob,
 	struct spdk_bs_cpl cpl;
 	struct spdk_bs_channel *ch;
 	struct spdk_blob_copy_cluster_ctx *ctx;
-	uint32_t cluster_start_page;
+	uint64_t cluster_start_page;
 	uint32_t cluster_number;
 	bool is_zeroes;
 	bool can_copy;
@@ -3296,7 +3296,7 @@ blob_request_submit_op_single(struct spdk_io_channel *_ch, struct spdk_blob *blo
 		if (spdk_blob_is_thin_provisioned(blob) && is_allocated &&
 		    bs_io_units_per_cluster(blob) == length && g_cluster_unmap_enabled) {
 			struct spdk_bs_channel *bs_channel = spdk_io_channel_get_ctx(_ch);
-			uint32_t cluster_start_page;
+			uint64_t cluster_start_page;
 			uint32_t cluster_number;
 
 			assert(offset % bs_io_units_per_cluster(blob) == 0);

--- a/lib/blob/blobstore.h
+++ b/lib/blob/blobstore.h
@@ -637,7 +637,7 @@ bs_num_io_units_to_cluster_boundary(struct spdk_blob *blob, uint64_t io_unit)
 }
 
 /* Given an io_unit offset into a blob, look up the number of pages into blob to beginning of current cluster */
-static inline uint32_t
+static inline uint64_t
 bs_io_unit_to_cluster_start(struct spdk_blob *blob, uint64_t io_unit)
 {
 	uint64_t	pages_per_cluster;
@@ -655,7 +655,7 @@ bs_io_unit_to_cluster_number(struct spdk_blob *blob, uint64_t io_unit)
 {
 	uint64_t	pages_per_cluster = blob->bs->pages_per_cluster;
 	uint8_t		shift = blob->bs->pages_per_cluster_shift;
-	uint32_t	page_offset;
+	uint64_t	page_offset;
 
 	page_offset = io_unit / bs_io_unit_per_page(blob->bs);
 	if (shift != 0) {


### PR DESCRIPTION
When creating blobstore on devices with more than 16 TiB space, the start page index of clusters can execeed UINT32_MAX and result in overflow in uint32_t representation.

Use uint64_t instead of uint32_t to avoid the overflow.

Change-Id: I8e2586251b1b31ef7520b870af537c3f5792508e

Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/24619
Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
Community-CI: Broadcom CI <spdk-ci.pdl@broadcom.com>
Reviewed-by: Jim Harris <jim.harris@samsung.com>
Community-CI: Mellanox Build Bot
Reviewed-by: Changpeng Liu <changpeliu@tencent.com>
Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
Reviewed-by: GangCao <gang.cao@intel.com>