### PR TITLE
Pull in blobstore fixes from upstream

### DIFF
--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -5089,6 +5089,11 @@ bs_load_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 	struct spdk_bs_load_ctx *ctx = cb_arg;
 	int rc;
 
+	if (bserrno != 0) {
+		bs_load_ctx_fail(ctx, bserrno);
+		return;
+	}
+
 	rc = bs_super_validate(ctx->super, ctx->bs);
 	if (rc != 0) {
 		bs_load_ctx_fail(ctx, rc);
@@ -5503,11 +5508,16 @@ bs_dump_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 	struct spdk_bs_load_ctx *ctx = cb_arg;
 	int rc;
 
+	if (bserrno != 0) {
+		bs_dump_finish(seq, ctx, bserrno);
+		return;
+	}
+
 	fprintf(ctx->fp, "Signature: \"%.8s\" ", ctx->super->signature);
 	if (memcmp(ctx->super->signature, SPDK_BS_SUPER_BLOCK_SIG,
 		   sizeof(ctx->super->signature)) != 0) {
 		fprintf(ctx->fp, "(Mismatch)\n");
-		bs_dump_finish(seq, ctx, bserrno);
+		bs_dump_finish(seq, ctx, -EILSEQ);
 		return;
 	} else {
 		fprintf(ctx->fp, "(OK)\n");
@@ -5603,17 +5613,32 @@ bs_init_persist_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 {
 	struct spdk_bs_load_ctx *ctx = cb_arg;
 
-	ctx->bs->used_clusters = spdk_bit_pool_create_from_array(ctx->used_clusters);
 	spdk_free(ctx->super);
-	free(ctx);
 
-	bs_sequence_finish(seq, bserrno);
+	if (bserrno != 0) {
+		bs_sequence_finish(seq, bserrno);
+		bs_free(ctx->bs);
+		spdk_bit_array_free(&ctx->used_clusters);
+	} else {
+		ctx->bs->used_clusters = spdk_bit_pool_create_from_array(ctx->used_clusters);
+		bs_sequence_finish(seq, bserrno);
+	}
+	free(ctx);
 }
 
 static void
 bs_init_trim_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 {
 	struct spdk_bs_load_ctx *ctx = cb_arg;
+
+	if (bserrno != 0) {
+		spdk_free(ctx->super);
+		bs_sequence_finish(seq, bserrno);
+		bs_free(ctx->bs);
+		spdk_bit_array_free(&ctx->used_clusters);
+		free(ctx);
+		return;
+	}
 
 	/* Write super block */
 	bs_sequence_write_dev(seq, ctx->super, bs_page_to_lba(ctx->bs, 0),
@@ -5626,7 +5651,7 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 	     spdk_bs_op_with_handle_complete cb_fn, void *cb_arg)
 {
 	struct spdk_bs_load_ctx *ctx;
-	struct spdk_blob_store	*bs;
+	struct spdk_blob_store	*bs = NULL;
 	struct spdk_bs_cpl	cpl;
 	spdk_bs_sequence_t	*seq;
 	spdk_bs_batch_t		*batch;
@@ -5643,31 +5668,26 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 	if ((dev->phys_blocklen % dev->blocklen) != 0) {
 		SPDK_ERRLOG("unsupported dev block length of %d\n",
 			    dev->blocklen);
-		dev->destroy(dev);
-		cb_fn(cb_arg, NULL, -EINVAL);
-		return;
+		rc = -EINVAL;
+		goto out;
 	}
 
 	spdk_bs_opts_init(&opts, sizeof(opts));
 	if (o) {
 		if (bs_opts_copy(o, &opts)) {
-			dev->destroy(dev);
-			cb_fn(cb_arg, NULL, -EINVAL);
-			return;
+			rc = -EINVAL;
+			goto out;
 		}
 	}
 
 	if (bs_opts_verify(&opts) != 0) {
-		dev->destroy(dev);
-		cb_fn(cb_arg, NULL, -EINVAL);
-		return;
+		rc = -EINVAL;
+		goto out;
 	}
 
 	rc = bs_alloc(dev, &opts, &bs, &ctx);
 	if (rc) {
-		dev->destroy(dev);
-		cb_fn(cb_arg, NULL, rc);
-		return;
+		goto out;
 	}
 
 	if (opts.num_md_pages == SPDK_BLOB_OPTS_NUM_MD_PAGES) {
@@ -5683,29 +5703,17 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 	}
 	rc = spdk_bit_array_resize(&bs->used_md_pages, bs->md_len);
 	if (rc < 0) {
-		spdk_free(ctx->super);
-		free(ctx);
-		bs_free(bs);
-		cb_fn(cb_arg, NULL, -ENOMEM);
-		return;
+		goto out;
 	}
 
 	rc = spdk_bit_array_resize(&bs->used_blobids, bs->md_len);
 	if (rc < 0) {
-		spdk_free(ctx->super);
-		free(ctx);
-		bs_free(bs);
-		cb_fn(cb_arg, NULL, -ENOMEM);
-		return;
+		goto out;
 	}
 
 	rc = spdk_bit_array_resize(&bs->open_blobids, bs->md_len);
 	if (rc < 0) {
-		spdk_free(ctx->super);
-		free(ctx);
-		bs_free(bs);
-		cb_fn(cb_arg, NULL, -ENOMEM);
-		return;
+		goto out;
 	}
 
 	memcpy(ctx->super->signature, SPDK_BS_SUPER_BLOCK_SIG,
@@ -5778,12 +5786,8 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 		SPDK_ERRLOG("Blobstore metadata cannot use more clusters than is available, "
 			    "please decrease number of pages reserved for metadata "
 			    "or increase cluster size.\n");
-		spdk_free(ctx->super);
-		spdk_bit_array_free(&ctx->used_clusters);
-		free(ctx);
-		bs_free(bs);
-		cb_fn(cb_arg, NULL, -ENOMEM);
-		return;
+		rc = -ENOMEM;
+		goto out;
 	}
 	/* Claim all of the clusters used by the metadata */
 	for (i = 0; i < num_md_clusters; i++) {
@@ -5800,11 +5804,8 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 
 	seq = bs_sequence_start_bs(bs->md_channel, &cpl);
 	if (!seq) {
-		spdk_free(ctx->super);
-		free(ctx);
-		bs_free(bs);
-		cb_fn(cb_arg, NULL, -ENOMEM);
-		return;
+		rc = -ENOMEM;
+		goto out;
 	}
 
 	batch = bs_sequence_to_batch(seq, bs_init_trim_cpl, ctx);
@@ -5829,6 +5830,18 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 	}
 
 	bs_batch_close(batch);
+	return;
+
+out:
+	if (bs) {
+		bs_free(ctx->bs);
+		spdk_free(ctx->super);
+		spdk_bit_array_free(&ctx->used_clusters);
+		free(ctx);
+	} else {
+		dev->destroy(dev);
+	}
+	cb_fn(cb_arg, NULL, rc);
 }
 
 /* END spdk_bs_init */

--- a/module/bdev/aio/bdev_aio.c
+++ b/module/bdev/aio/bdev_aio.c
@@ -66,6 +66,7 @@ struct bdev_aio_io_channel {
 #endif
 	struct bdev_aio_group_channel		*group_ch;
 	TAILQ_ENTRY(bdev_aio_io_channel)	link;
+	bool					detached;
 };
 
 struct bdev_aio_group_channel {
@@ -543,31 +544,34 @@ bdev_aio_io_channel_poll(struct bdev_aio_io_channel *io_ch)
 		rc = (int)events[i].res;
 		fdisk = fdisk_from_bdev(bdev_io->bdev);
 
-		/* When the block device device is detached from the system, IOs fail with res of 0.
+		/* Since spdk_fd_get_size is not cost-free, we prioritize the check for -EAGAIN as
+		 * it's not likely that this error is returned when a device is detached.
+		 */
+		if (rc == -EAGAIN) {
+			spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+			continue;
+		}
+
+		/* When the block device device is detached from the system, IOs fail with different
+		 * observed res such as 0, -EIO or -ENOSPC.
 		 * In this case the ioctl BLKGETSIZE64 yields a device size of 0.
 		 * Note that re-attaching the device will not correct this because the existing fd is
 		 * still invalid.
-		 * When the fd is a file and the mount backing the file is detached, IOs fail
-		 * with a res of -EIO and the ioctl BLKGETSIZE64 yields a device size of 0.
 		 */
-		if (rc == -EIO || rc >= 0) {
-			if (spdk_fd_get_size(fdisk->fd) == 0) {
-				rc = -ENODEV;
-			}
+		if (!io_ch->detached && spdk_fd_get_size(fdisk->fd) == 0) {
+			io_ch->detached = true;
 		}
 
+		if (io_ch->detached) {
+			bdev_aio_try_hot_remove(fdisk);
+			spdk_bdev_io_complete_aio_status(bdev_io, -ENODEV);
+			continue;
+		}
+
+		AIO_FDISK_ERRLOG(fdisk, "failed to complete: rc %"PRId64"\n", events[i].res);
 		if (rc < 0) {
-			if (rc == -EAGAIN) {
-				spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
-			} else if (rc == -ENODEV) {
-				bdev_aio_try_hot_remove(fdisk);
-				spdk_bdev_io_complete_aio_status(bdev_io, rc);
-			} else {
-				AIO_FDISK_ERRLOG(fdisk, "failed to complete: rc %"PRId64"\n", events[i].res);
-				spdk_bdev_io_complete_aio_status(bdev_io, rc);
-			}
+			spdk_bdev_io_complete_aio_status(bdev_io, rc);
 		} else {
-			AIO_FDISK_ERRLOG(fdisk, "failed to complete: rc %"PRId64"\n", events[i].res);
 			spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
 		}
 	}

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -1804,7 +1804,7 @@ _vbdev_lvs_examine_cb(void *arg, struct spdk_lvol_store *lvol_store, int lvserrn
 		_vbdev_lvs_examine_done(ori_req, lvserrno);
 		goto end;
 	} else if (lvserrno != 0) {
-		SPDK_INFOLOG(vbdev_lvol, "Lvol store not found on %s\n", req->base_bdev->name);
+		SPDK_INFOLOG(vbdev_lvol, "Lvol store not found on %s: %d\n", req->base_bdev->name, lvserrno);
 		/* On error blobstore destroys bs_dev itself */
 		_vbdev_lvs_examine_done(ori_req, lvserrno);
 		goto end;

--- a/test/lvol/disk_errors.sh
+++ b/test/lvol/disk_errors.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#  SPDX-License-Identifier: BSD-3-Clause
+#  Copyright (C) 2019 Intel Corporation
+#  All rights reserved.
+#
+testdir=$(readlink -f $(dirname $0))
+rootdir=$(readlink -f $testdir/../..)
+source $rootdir/test/common/autotest_common.sh
+source $rootdir/test/lvol/common.sh
+LOG_PATH="$rootdir/test/lvol/spdk.log"
+
+# try to examine lvs on top of bdev failing all I/O
+function test_examine_lvs_on_failing_bdev() {
+	malloc_name=$(rpc_cmd bdev_malloc_create $MALLOC_SIZE_MB $MALLOC_BS)
+	error_name="EE_$malloc_name"
+	pt_name="PT_$error_name"
+
+	rpc_cmd bdev_error_create "$malloc_name"
+	rpc_cmd "bdev_wait_for_examine"
+	# error bdev fails to examine with -EILSEQ because it's created with no errors
+	grep -q "Lvol store not found on $error_name: -84" $LOG_PATH
+
+	# enable errors on the error bdev
+	rpc_cmd bdev_error_inject_error "$error_name" 'all' 'failure' -n 1000
+	# create passthru bdev so we can inspect the examine import error
+	rpc_cmd bdev_passthru_create -b "$error_name" -p "$pt_name"
+	rpc_cmd "bdev_wait_for_examine"
+	# This one should fail with -EIO as we should not try to validate the blob signature
+	grep -q "Lvol store not found on $pt_name: -5" $LOG_PATH
+
+	# clean up
+	rpc_cmd bdev_lvol_get_lvstores -l lvs && false
+	rpc_cmd bdev_passthru_delete "$pt_name"
+	rpc_cmd bdev_error_delete "$error_name"
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	rpc_cmd bdev_get_bdevs -b "$malloc_name" && false
+	check_leftover_devices
+}
+
+# try to create lvs on top of bdev failing all I/O
+# upon failure, blobstore should clean up and bdev delete should not get stuck
+function test_construct_lvs_on_failing_bdev() {
+	malloc_name=$(rpc_cmd bdev_malloc_create $MALLOC_SIZE_MB $MALLOC_BS)
+	error_name="EE_$malloc_name"
+
+	rpc_cmd bdev_error_create "$malloc_name"
+
+	# enable errors on the error bdev
+	rpc_cmd bdev_error_inject_error "$error_name" 'all' 'failure' -n 1000
+
+	rpc_cmd bdev_lvol_create_lvstore "$error_name" lvs && false
+
+	# clean up
+	rpc_cmd bdev_lvol_get_lvstores -l lvs && false
+	rpc_cmd bdev_error_delete "$error_name"
+	rpc_cmd bdev_get_bdevs -b "$error_name" && false
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	rpc_cmd bdev_get_bdevs -b "$malloc_name" && false
+	check_leftover_devices
+}
+
+# try to delete lvs on top of bdev failing all I/O
+# upon failure, blobstore and bdev delete should not get stuck
+function test_delete_lvs_on_failing_bdev() {
+	malloc_name=$(rpc_cmd bdev_malloc_create $MALLOC_SIZE_MB $MALLOC_BS)
+	error_name="EE_$malloc_name"
+
+	rpc_cmd bdev_error_create "$malloc_name"
+	rpc_cmd bdev_lvol_create_lvstore "$error_name" lvs
+
+	# enable errors on the error bdev
+	rpc_cmd bdev_error_inject_error "$error_name" 'all' 'failure' -n 1000
+
+	rpc_cmd bdev_lvol_delete_lvstore -l lvs
+
+	# clean up
+	rpc_cmd bdev_lvol_get_lvstores -l lvs && false
+	rpc_cmd bdev_error_delete "$error_name"
+	rpc_cmd bdev_get_bdevs -b "$error_name" && false
+	rpc_cmd bdev_malloc_delete "$malloc_name"
+	rpc_cmd bdev_get_bdevs -b "$malloc_name" && false
+	check_leftover_devices
+}
+
+$SPDK_BIN_DIR/spdk_tgt -Lvbdev_lvol &> $LOG_PATH &
+spdk_pid=$!
+trap 'killprocess "$spdk_pid"; rm "$LOG_PATH"; exit 1' SIGINT SIGTERM EXIT
+waitforlisten $spdk_pid
+
+run_test "test_examine_lvs_on_failing_bdev" test_examine_lvs_on_failing_bdev
+run_test "test_construct_lvs_on_failing_bdev" test_construct_lvs_on_failing_bdev
+run_test "test_delete_lvs_on_failing_bdev" test_delete_lvs_on_failing_bdev
+
+trap - SIGINT SIGTERM EXIT
+if ps -p $spdk_pid; then
+	killprocess $spdk_pid
+fi
+rm "$LOG_PATH" | :

--- a/test/lvol/lvol.sh
+++ b/test/lvol/lvol.sh
@@ -14,6 +14,7 @@ timing_enter basic
 run_test "lvol_basic" $rootdir/test/lvol/basic.sh
 run_test "lvol_resize" $rootdir/test/lvol/resize.sh
 run_test "lvol_hotremove" $rootdir/test/lvol/hotremove.sh
+run_test "lvol_disk_errors" $rootdir/test/lvol/disk_errors.sh
 run_test "lvol_tasting" $rootdir/test/lvol/tasting.sh
 run_test "lvol_snapshot_clone" $rootdir/test/lvol/snapshot_clone.sh
 run_test "lvol_rename" $rootdir/test/lvol/rename.sh

--- a/test/unit/lib/blob/blob.c/blob_ut.c
+++ b/test/unit/lib/blob/blob.c/blob_ut.c
@@ -255,6 +255,7 @@ blob_init(void)
 {
 	struct spdk_blob_store *bs;
 	struct spdk_bs_dev *dev;
+	struct spdk_power_failure_thresholds thresholds = {};
 
 	dev = init_dev();
 
@@ -263,6 +264,28 @@ blob_init(void)
 	spdk_bs_init(dev, NULL, bs_op_with_handle_complete, NULL);
 	poll_threads();
 	CU_ASSERT(g_bserrno == -EINVAL);
+
+	/* should handle unmap failure */
+	dev = init_dev();
+	thresholds.unmap_threshold = 1;
+	dev_set_power_failure_thresholds(thresholds);
+	spdk_bs_init(dev, NULL, bs_op_with_handle_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno != 0);
+	SPDK_CU_ASSERT_FATAL(g_bs == NULL);
+	memset(&thresholds, 0, sizeof(thresholds));
+	dev_reset_power_failure_event();
+
+	/* should handle super block write failure */
+	dev = init_dev();
+	thresholds.write_threshold = 1;
+	dev_set_power_failure_thresholds(thresholds);
+	spdk_bs_init(dev, NULL, bs_op_with_handle_complete, NULL);
+	poll_threads();
+	CU_ASSERT(g_bserrno != 0);
+	SPDK_CU_ASSERT_FATAL(g_bs == NULL);
+	memset(&thresholds, 0, sizeof(thresholds));
+	dev_reset_power_failure_event();
 
 	dev = init_dev();
 	spdk_bs_init(dev, NULL, bs_op_with_handle_complete, NULL);


### PR DESCRIPTION
    lib/blobstore: handle failure I/O failures
    
    Pulls changes from upstream spdk:
    - 3076526082cd30d5fcb912ccf06cc15793149f0c
    - 8868e418e57f6ce35663dc1acc1d3c4ba5d33480
    - ba0f4a7ab23d770bbdf10f5ff356a8ca925ff9ca
    
---

    bdev: check hot-removal on non -EAGAIN/-EWOULDBLOCK
    
    During my testing I see -ENOSPC being returned, for writes.
    Change logic to check for everything other than -EAGAIN, to avoid
    calling spdk_get_size since it's not a zero cost call.
    
    Pulls changes from upstream spdk:
    0e4cb615cd3d2be05c18b8a6072cc5f2d495545e
    37a294c8d9d5065b2bdb1a2f63cc2831a473cb0e
