### PR TITLE
lib/blobstore: add new clone api for non-snapshot clones

### DIFF
--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -727,6 +727,27 @@ int spdk_blob_get_clones(struct spdk_blob_store *bs, spdk_blob_id blobid, spdk_b
 			 size_t *count);
 
 /**
+ * Provide table with blob id's of clones are dependent on specified snapshot.
+ * These clones are not snapshots.
+ *
+ * Ids array should be allocated and the count parameter set to the number of
+ * id's it can store, before calling this function.
+ *
+ * If ids is NULL or count parameter is not sufficient to handle ids of all
+ * clones, -ENOMEM error is returned and count parameter is updated to the
+ * total number of clones.
+ *
+ * \param bs blobstore.
+ * \param blobid Snapshots blob id.
+ * \param ids Array of the clone ids or NULL to get required size in count.
+ * \param count Size of ids. After call it is updated to the number of clones.
+ *
+ * \return -ENOMEM if count is not sufficient to store all clones.
+ */
+int spdk_blob_get_real_clones(struct spdk_blob_store *bs, spdk_blob_id blobid, spdk_blob_id *ids,
+			      size_t *count);
+
+/**
  * Get the blob id for the parent snapshot of this blob.
  *
  * \param bs blobstore.

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -9971,6 +9971,42 @@ spdk_blob_get_parent_snapshot(struct spdk_blob_store *bs, spdk_blob_id blob_id)
 }
 
 int
+spdk_blob_get_real_clones(struct spdk_blob_store *bs, spdk_blob_id blobid, spdk_blob_id *ids,
+			  size_t *count)
+{
+	struct spdk_blob_list *snapshot_entry, *clone_entry;
+	size_t n;
+
+	snapshot_entry = bs_get_snapshot_entry(bs, blobid);
+	if (snapshot_entry == NULL) {
+		*count = 0;
+		return 0;
+	}
+
+	if (ids == NULL || *count < snapshot_entry->clone_count) {
+		n = 0;
+		TAILQ_FOREACH(clone_entry, &snapshot_entry->clones, link) {
+			if (bs_get_snapshot_entry(bs, clone_entry->id)) {
+				n++;
+			}
+		}
+		*count = n;
+
+		return -ENOMEM;
+	}
+	*count = snapshot_entry->clone_count;
+
+	n = 0;
+	TAILQ_FOREACH(clone_entry, &snapshot_entry->clones, link) {
+		if (bs_get_snapshot_entry(bs, clone_entry->id)) {
+			ids[n++] = clone_entry->id;
+		}
+	}
+
+	return 0;
+}
+
+int
 spdk_blob_get_clones(struct spdk_blob_store *bs, spdk_blob_id blobid, spdk_blob_id *ids,
 		     size_t *count)
 {


### PR DESCRIPTION
The mayastor snapshot api is currently reporting snapshot clones only if they are actual clones created from a replica.

The spdk snapshot num_clones includes all clones, which may also be snapshots.

We provide a new method spdk_blob_get_real_clones which adds the check to ensure each clone is a "real clone" and not a snapshot.