### PR TITLE
fix: interrupt mode compatibility for custom reactors

### DIFF
--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -620,6 +620,15 @@ bdev_wait_for_examine_cb(void *arg)
 	return SPDK_POLLER_BUSY;
 }
 
+static void
+bdev_wait_for_examine_msg_cb(void *arg)
+{
+	struct spdk_bdev_wait_for_examine_ctx *ctx = arg;
+
+	ctx->cb_fn(ctx->cb_arg);
+	free(ctx);
+}
+
 int
 spdk_bdev_wait_for_examine(spdk_bdev_wait_for_examine_cb cb_fn, void *cb_arg)
 {
@@ -631,7 +640,22 @@ spdk_bdev_wait_for_examine(spdk_bdev_wait_for_examine_cb cb_fn, void *cb_arg)
 	}
 	ctx->cb_fn = cb_fn;
 	ctx->cb_arg = cb_arg;
-	ctx->poller = SPDK_POLLER_REGISTER(bdev_wait_for_examine_cb, ctx, 0);
+
+	/* Fast path: if all examine actions are already complete, defer the
+	 * callback via a thread message instead of installing a poller. The
+	 * message preserves the async contract (callback runs on the next
+	 * thread poll, not during this call) and avoids installing an
+	 * always-readable eventfd (period=0) that would spin fd_group_wait()
+	 * in interrupt mode. A 1 ms periodic poller is still used when
+	 * examine is genuinely asynchronous; its timerfd fires in both poll
+	 * and interrupt modes. */
+	if (bdev_module_all_actions_completed()) {
+		spdk_thread_send_msg(spdk_get_thread(),
+				     bdev_wait_for_examine_msg_cb, ctx);
+		return 0;
+	}
+
+	ctx->poller = SPDK_POLLER_REGISTER(bdev_wait_for_examine_cb, ctx, 1000);
 
 	return 0;
 }

--- a/lib/iscsi/iscsi_subsystem.c
+++ b/lib/iscsi/iscsi_subsystem.c
@@ -997,6 +997,7 @@ iscsi_poll_group_create(void *io_device, void *ctx_buf)
 	assert(pg->sock_group != NULL);
 
 	pg->poller = SPDK_POLLER_REGISTER(iscsi_poll_group_poll, pg, 0);
+	spdk_poller_register_interrupt(pg->poller, NULL, NULL);
 	/* set the period to 1 sec */
 	pg->nop_poller = SPDK_POLLER_REGISTER(iscsi_poll_group_handle_nop, pg, 1000000);
 


### PR DESCRIPTION
## Summary

Two fixes for SPDK interrupt mode compatibility with custom reactors that
block in `fd_group_wait()` instead of using SPDK's stock reactor loop:

- **iSCSI poll group**: Register interrupt to suppress always-readable eventfd
  that prevents `fd_group_wait()` from blocking. Follows existing pattern in
  NVMf TCP, NVMe bdev, and AIO bdev modules.
- **bdev wait_for_examine**: Replace busy poller (period=0) with 1ms periodic
  poller. A busy poller's eventfd spins `fd_group_wait()`; suppressing it via
  `spdk_poller_register_interrupt(NULL, NULL)` removes all interrupt sources so
  the poller never fires — bdev examine never completes and
  `spdk_bdev_unregister()` returns EBUSY, hanging destroy operations.

Both issues are specific to reactors that block in `fd_group_wait()` rather
than using SPDK's stock reactor loop (which services busy pollers regardless
of interrupt-mode state). SPDK's stock reactor and Longhorn v2 are unaffected.

Ref: openebs/mayastor#1745

## Test plan

- [x] 73/86 mayastor pytest tests pass with interrupt mode enabled
- [x] Validated on 3-node production cluster (16 volumes, 10+ days uptime)
- [x] No regressions in poll mode (all tests identical with and without fix)