### PR TITLE
lib/lvol: revert blob cache

### DIFF
--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -583,16 +583,6 @@ uint64_t spdk_blob_get_next_allocated_io_unit(struct spdk_blob *blob, uint64_t o
  */
 uint64_t spdk_blob_get_next_unallocated_io_unit(struct spdk_blob *blob, uint64_t offset);
 
-/**
- * Calculate the number of clusters used by the blob. Equal to number of allocated clusters for thick provisioned
- * blobs, less or equal to number of allocated clusters for thin provisioned blobs.
- *
- * \param blob Blob struct to query.
- *
- * \return the number of allocated clusters.
- */
-uint64_t spdk_blob_calc_used_clusters(struct spdk_blob *blob);
-
 struct spdk_blob_xattr_opts {
 	/* Number of attributes */
 	size_t	count;
@@ -1342,12 +1332,6 @@ struct spdk_bs_dev *spdk_blob_get_esnap_bs_dev(const struct spdk_blob *blob);
  * \return true if the blob or any snapshots upon which it depends are degraded, else false.
  */
 bool spdk_blob_is_degraded(const struct spdk_blob *blob);
-
-/**
- * Reset num_used_clusters_cache, if blob is thin provisioned.
- * \param blob for which need to reset the usage cache.
- */
-void spdk_blob_reset_used_clusters_cache(struct spdk_blob *blob);
 
 /**
  * Blob get cluster bitmap completion callback.

--- a/include/spdk_internal/lvolstore.h
+++ b/include/spdk_internal/lvolstore.h
@@ -141,11 +141,4 @@ void spdk_lvs_esnap_missing_remove(struct spdk_lvol *lvol);
 bool spdk_lvs_notify_hotplug(const void *esnap_id, uint32_t id_len,
 			     spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg);
 
-/**
- * Reset num_used_clusters_cache, if blob is thin provisioned and snapshot is
- * created from it. New snapshot will own the data, hence the clusted information
- * present in the blob cache can be cleared.
- */
-void blob_reset_used_clusters_cache(struct spdk_blob *blob);
-
 #endif /* SPDK_INTERNAL_LVOLSTORE_H */

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -187,9 +187,6 @@ bs_allocate_cluster(struct spdk_blob *blob, uint32_t cluster_num,
 
 	assert(spdk_spin_held(&blob->bs->used_lock));
 
-	/* Reset cache of used clusters */
-	blob->num_used_clusters_cache = 0;
-
 	*cluster = bs_claim_cluster(blob->bs);
 	if (*cluster == UINT32_MAX) {
 		/* No more free clusters. Cannot satisfy the request */
@@ -274,7 +271,7 @@ spdk_blob_get_num_clusters_ancestors(struct spdk_blob_store *bs, struct spdk_blo
 			return -ENXIO;
 		}
 
-		clusters += spdk_blob_calc_used_clusters(b);
+		clusters += b->active.num_allocated_clusters;
 	}
 
 	*num_clusters = clusters;
@@ -6354,50 +6351,6 @@ uint64_t
 spdk_blob_get_next_unallocated_io_unit(struct spdk_blob *blob, uint64_t offset)
 {
 	return blob_find_io_unit(blob, offset, false);
-}
-
-uint64_t
-spdk_blob_calc_used_clusters(struct spdk_blob *blob)
-{
-	size_t i;
-	uint64_t num;
-
-	assert(blob != NULL);
-
-	if (!spdk_blob_is_thin_provisioned(blob)) {
-		return spdk_blob_get_num_clusters(blob);
-	}
-
-	spdk_spin_lock(&blob->bs->used_lock);
-
-	if (blob->num_used_clusters_cache > 0) {
-		num = blob->num_used_clusters_cache;
-		spdk_spin_unlock(&blob->bs->used_lock);
-		return num;
-	}
-
-	num = 0;
-	for (i = 0; i < blob->active.cluster_array_size; ++i) {
-		if (blob->active.clusters[i] != 0) {
-			++num;
-		}
-	}
-	blob->num_used_clusters_cache = num;
-
-	spdk_spin_unlock(&blob->bs->used_lock);
-
-	return num;
-}
-
-void
-spdk_blob_reset_used_clusters_cache(struct spdk_blob *blob)
-{
-	assert(blob != NULL);
-	if (spdk_blob_is_thin_provisioned(blob)) {
-		spdk_spin_lock(&blob->bs->used_lock);
-		blob->num_used_clusters_cache = 0;
-		spdk_spin_unlock(&blob->bs->used_lock);
-	}
 }
 
 struct spdk_blob_bitmap_ctx {

--- a/lib/blob/blobstore.h
+++ b/lib/blob/blobstore.h
@@ -151,9 +151,6 @@ struct spdk_blob {
 	/* Number of data clusters retrieved from extent table,
 	 * that many have to be read from extent pages. */
 	uint64_t	remaining_clusters_in_et;
-
-	/* Cache number of used cluster for a thin provisioned blob. */
-	uint64_t	num_used_clusters_cache;
 };
 
 struct spdk_blob_store {

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -1171,9 +1171,6 @@ lvol_create_snapshot_cb(void *cb_arg, spdk_blob_id blobid, int lvolerrno)
 {
 	struct spdk_lvol_snapshot_req *snap_req = cb_arg;
 
-	if (lvolerrno == 0) {
-		spdk_blob_reset_used_clusters_cache(snap_req->parent->blob);
-	}
 	snap_req->orig_cb_fn(snap_req->orig_cb_arg, blobid, lvolerrno);
 	free(cb_arg);
 }


### PR DESCRIPTION
Revert the added blob cache and use the blob's num_allocated_clusters The cache was just a short-term solution and it's not needed since we can get the clusters from the spdk blob.