### PR TITLE
fix(nvmf): avoid null controller dereference during subsystem pause

### DIFF
--- a/lib/nvmf/ctrlr.c
+++ b/lib/nvmf/ctrlr.c
@@ -4859,7 +4859,6 @@ nvmf_check_subsystem_active(struct spdk_nvmf_request *req)
 	struct spdk_nvmf_subsystem_poll_group *sgroup = NULL;
 	struct spdk_nvmf_subsystem_pg_ns_info *ns_info;
 	uint32_t nsid;
-	struct spdk_nvmf_subsystem *subsystem;
 
 	if (spdk_likely(qpair->ctrlr)) {
 		sgroup = &qpair->group->sgroups[qpair->ctrlr->subsys->id];
@@ -4876,9 +4875,9 @@ nvmf_check_subsystem_active(struct spdk_nvmf_request *req)
 	if (spdk_unlikely(req->cmd->nvmf_cmd.opcode == SPDK_NVME_OPC_FABRIC ||
 			  nvmf_qpair_is_admin_queue(qpair))) {
 		if (sgroup->state != SPDK_NVMF_SUBSYSTEM_ACTIVE) {
-			subsystem = qpair->ctrlr->subsys;
-			if (req->cmd->nvmf_cmd.opcode != SPDK_NVME_OPC_FABRIC &&
-			    (subsystem->pause_flags & SPDK_NVMF_SUBSYSTEM_PAUSE_KEEP_ADMINQ)) {
+			if (qpair->ctrlr &&
+			    req->cmd->nvmf_cmd.opcode != SPDK_NVME_OPC_FABRIC &&
+			    (qpair->ctrlr->subsys->pause_flags & SPDK_NVMF_SUBSYSTEM_PAUSE_KEEP_ADMINQ)) {
 				/*
 				 * Vendor maintenance pause
 				 * allow normal admin queue commands while data IO is paused


### PR DESCRIPTION
Fabric Connect requests may be processed while a subsystem is paused and before controller creation completes, or after controller teardown has started.

In this case a valid subsystem poll group may exist while qpair->ctrlr is NULL. Accessing qpair->ctrlr->subsys->pause_flags during the paused-subsystem path can therefore result in a NULL pointer dereference.

Guard access to the controller before evaluating the SPDK_NVMF_SUBSYSTEM_PAUSE_KEEP_ADMINQ pause flag.