### PR TITLE
bdev/aio, bdev/uring: async UNMAP and WRITE_ZEROES

### DIFF
--- a/module/bdev/aio/bdev_aio.c
+++ b/module/bdev/aio/bdev_aio.c
@@ -25,6 +25,10 @@
 
 #ifndef __FreeBSD__
 #include <libaio.h>
+#include <linux/fs.h>
+#include <sys/ioctl.h>
+#include <sys/sysmacros.h>
+#include <sched.h>
 #endif
 
 /* It's not safe to always assume RWF_NOWAIT is supported by a block device.
@@ -89,6 +93,9 @@ struct bdev_aio_task {
 	struct bdev_aio_io_channel	*ch;
 };
 
+/* Maps an UNMAP/WRITE_ZEROES range to a backing syscall (ioctl or fallocate). */
+typedef int (*aio_range_fn)(int fd, uint64_t range[2]);
+
 struct file_disk {
 	struct bdev_aio_task	*reset_task;
 	struct spdk_poller	*reset_retry_timer;
@@ -102,6 +109,8 @@ struct file_disk {
 	bool			block_size_override;
 	bool			readonly;
 	bool			fallocate;
+	aio_range_fn		unmap;
+	aio_range_fn		zero;
 
 	bool			hot_remove_in_progress;
 };
@@ -149,6 +158,193 @@ static struct spdk_bdev_module aio_if = {
 };
 
 SPDK_BDEV_MODULE_REGISTER(aio, &aio_if)
+
+#ifndef __FreeBSD__
+
+/*
+ * Asynchronous offload of blocking range operations (UNMAP / WRITE_ZEROES).
+ *
+ * fallocate() and ioctl(BLKDISCARD)/ioctl(BLKZEROOUT) run synchronously in the
+ * kernel and can block for tens to hundreds of milliseconds (longer for a whole-
+ * device discard). Running them inline on the SPDK reactor stalls every other
+ * volume sharing that core - the reason aio-bdev trim was historically left off.
+ * Instead we hand each range op to a single worker thread pinned off the reactor
+ * cores and complete the bdev_io back on the originating thread via
+ * spdk_thread_send_msg(). This revives the reverted openebs/spdk#11.
+ */
+
+struct aio_offload_req {
+	struct spdk_bdev_io	*bdev_io;
+	struct spdk_thread	*orig_thread;
+	int			fd;
+	aio_range_fn		fn;
+	uint64_t		range[2];	/* {offset_bytes, length_bytes} */
+	int			result;		/* 0 on success, -errno on failure */
+};
+
+#define AIO_OFFLOAD_RING_SIZE	1024
+#define AIO_OFFLOAD_BATCH	64
+
+static struct spdk_ring		*g_aio_offload_ring;
+static pthread_t		g_aio_offload_thread;
+static pthread_mutex_t		g_aio_offload_mutex;
+static pthread_cond_t		g_aio_offload_cond;
+static bool			g_aio_offload_exit;
+
+static void
+aio_offload_complete(void *arg)
+{
+	struct aio_offload_req *req = arg;
+
+	if (req->result == 0) {
+		spdk_bdev_io_complete(req->bdev_io, SPDK_BDEV_IO_STATUS_SUCCESS);
+	} else {
+		spdk_bdev_io_complete_aio_status(req->bdev_io, req->result);
+	}
+
+	free(req);
+}
+
+static void
+aio_offload_execute(struct aio_offload_req *req)
+{
+	int rc = req->fn(req->fd, req->range);
+
+	req->result = (rc == 0) ? 0 : -errno;
+
+	/* Completion must run on the SPDK thread that submitted the bdev_io. */
+	spdk_thread_send_msg(req->orig_thread, aio_offload_complete, req);
+}
+
+static void *
+aio_offload_worker(void *arg)
+{
+	void *msgs[AIO_OFFLOAD_BATCH];
+	size_t count, i;
+
+	pthread_mutex_lock(&g_aio_offload_mutex);
+
+	for (;;) {
+		for (;;) {
+			count = spdk_ring_dequeue(g_aio_offload_ring, msgs, AIO_OFFLOAD_BATCH);
+			if (count == 0) {
+				break;
+			}
+
+			pthread_mutex_unlock(&g_aio_offload_mutex);
+			for (i = 0; i < count; i++) {
+				aio_offload_execute(msgs[i]);
+			}
+			pthread_mutex_lock(&g_aio_offload_mutex);
+		}
+
+		if (g_aio_offload_exit) {
+			break;
+		}
+
+		pthread_cond_wait(&g_aio_offload_cond, &g_aio_offload_mutex);
+	}
+
+	pthread_mutex_unlock(&g_aio_offload_mutex);
+
+	return NULL;
+}
+
+static int
+aio_offload_submit(struct aio_offload_req *req)
+{
+	size_t count = spdk_ring_count(g_aio_offload_ring);
+
+	if (spdk_ring_enqueue(g_aio_offload_ring, (void **)&req, 1, NULL) == 0) {
+		return -1;
+	}
+
+	/* Wake the worker only on the empty->non-empty transition. */
+	if (count == 0) {
+		pthread_mutex_lock(&g_aio_offload_mutex);
+		pthread_cond_signal(&g_aio_offload_cond);
+		pthread_mutex_unlock(&g_aio_offload_mutex);
+	}
+
+	return 0;
+}
+
+/* Pin the worker to the cores SPDK is NOT using for its reactors. */
+static void
+aio_offload_set_affinity(pthread_attr_t *attr)
+{
+	cpu_set_t cpuset;
+	unsigned i, cores;
+
+	CPU_ZERO(&cpuset);
+
+	cores = sysconf(_SC_NPROCESSORS_CONF);
+	for (i = 0; i < cores; i++) {
+		CPU_SET(i, &cpuset);
+	}
+
+	SPDK_ENV_FOREACH_CORE(i) {
+		CPU_CLR(i, &cpuset);
+	}
+
+	if (CPU_COUNT(&cpuset) > 0) {
+		pthread_attr_setaffinity_np(attr, sizeof(cpu_set_t), &cpuset);
+	}
+}
+
+static int
+aio_offload_init(void)
+{
+	pthread_attr_t attr;
+	int rc;
+
+	g_aio_offload_ring = spdk_ring_create(SPDK_RING_TYPE_MP_SC, AIO_OFFLOAD_RING_SIZE,
+					      SPDK_ENV_SOCKET_ID_ANY);
+	if (g_aio_offload_ring == NULL) {
+		return -ENOMEM;
+	}
+
+	g_aio_offload_exit = false;
+	pthread_mutex_init(&g_aio_offload_mutex, NULL);
+	pthread_cond_init(&g_aio_offload_cond, NULL);
+
+	pthread_attr_init(&attr);
+	aio_offload_set_affinity(&attr);
+	rc = pthread_create(&g_aio_offload_thread, &attr, aio_offload_worker, NULL);
+	pthread_attr_destroy(&attr);
+
+	if (rc != 0) {
+		spdk_ring_free(g_aio_offload_ring);
+		g_aio_offload_ring = NULL;
+		pthread_cond_destroy(&g_aio_offload_cond);
+		pthread_mutex_destroy(&g_aio_offload_mutex);
+		return -rc;
+	}
+
+	return 0;
+}
+
+static void
+aio_offload_fini(void)
+{
+	if (g_aio_offload_ring == NULL) {
+		return;
+	}
+
+	pthread_mutex_lock(&g_aio_offload_mutex);
+	g_aio_offload_exit = true;
+	pthread_cond_signal(&g_aio_offload_cond);
+	pthread_mutex_unlock(&g_aio_offload_mutex);
+
+	pthread_join(g_aio_offload_thread, NULL);
+
+	spdk_ring_free(g_aio_offload_ring);
+	g_aio_offload_ring = NULL;
+	pthread_cond_destroy(&g_aio_offload_cond);
+	pthread_mutex_destroy(&g_aio_offload_mutex);
+}
+
+#endif /* __FreeBSD__ */
 
 static int
 bdev_aio_open(struct file_disk *disk)
@@ -303,43 +499,150 @@ bdev_aio_flush(struct file_disk *fdisk, struct bdev_aio_task *aio_task)
 }
 
 #ifndef __FreeBSD__
-static void
-bdev_aio_fallocate(struct spdk_bdev_io *bdev_io, int mode)
+/* Zero/free a range of a (sparse) file by punching a hole; reads back as zeros. */
+static int
+aio_range_fallocate_punch(int fd, uint64_t range[2])
 {
-	struct file_disk *fdisk = fdisk_from_bdev(bdev_io->bdev);
-	struct bdev_aio_task *aio_task = (struct bdev_aio_task *)bdev_io->driver_ctx;
-	uint64_t offset_bytes = bdev_io->u.bdev.offset_blocks * bdev_io->bdev->blocklen;
-	uint64_t length_bytes = bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen;
-	int rc;
+	return fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, range[0], range[1]);
+}
 
-	if (!fdisk->fallocate) {
-		spdk_bdev_io_complete_aio_status(spdk_bdev_io_from_ctx(aio_task), -ENOTSUP);
+/* Discard a range of a block device (the device deallocates the blocks). */
+static int
+aio_range_blkdiscard(int fd, uint64_t range[2])
+{
+	return ioctl(fd, BLKDISCARD, range);
+}
+
+/* Zero a range of a block device (may deallocate; always reads back as zeros). */
+static int
+aio_range_blkzeroout(int fd, uint64_t range[2])
+{
+	return ioctl(fd, BLKZEROOUT, range);
+}
+
+/*
+ * Read a block device's queue limit (e.g. discard_max_bytes) from sysfs, or 0
+ * if it cannot be determined. Used to advertise only the trim operations the
+ * device actually supports.
+ */
+static uint64_t
+aio_dev_queue_limit(const struct stat *st, const char *attr)
+{
+	char path[64];
+	char buf[32];
+	int fd;
+	ssize_t n;
+
+	snprintf(path, sizeof(path), "/sys/dev/block/%u:%u/queue/%s",
+		 major(st->st_rdev), minor(st->st_rdev), attr);
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		return 0;
+	}
+	n = read(fd, buf, sizeof(buf) - 1);
+	close(fd);
+	if (n <= 0) {
+		return 0;
+	}
+	buf[n] = '\0';
+	return strtoull(buf, NULL, 10);
+}
+
+/*
+ * Decide, once at open time, how UNMAP and WRITE_ZEROES map to syscalls for this
+ * backing store. Only wired up when the operator opted in via fallocate=true (the
+ * io-engine side opts in only after probing that the backing store supports it).
+ * Leaving disk->unmap / disk->zero NULL means that io type is not advertised.
+ *   - block device: UNMAP -> BLKDISCARD, WRITE_ZEROES -> BLKZEROOUT, each
+ *     advertised only when the device's queue limits report support
+ *   - regular file:  UNMAP / WRITE_ZEROES -> fallocate(PUNCH_HOLE)
+ */
+static void
+set_aio_range_functions(struct file_disk *disk)
+{
+	struct stat st;
+
+	disk->unmap = NULL;
+	disk->zero = NULL;
+
+	if (!disk->fallocate) {
 		return;
 	}
 
-	rc = fallocate(fdisk->fd, mode, offset_bytes, length_bytes);
-	if (rc == 0) {
-		spdk_bdev_io_complete(spdk_bdev_io_from_ctx(aio_task), SPDK_BDEV_IO_STATUS_SUCCESS);
+	if (fstat(disk->fd, &st) < 0) {
+		AIO_FDISK_ERRLOG(disk, "fstat() failed, errno %d: %s\n", errno, spdk_strerror(errno));
+		return;
+	}
+
+	if (S_ISBLK(st.st_mode)) {
+		/* Advertise each op only where the device supports it, so UNMAP works on
+		 * discard-only devices and WRITE_ZEROES is not offered where BLKZEROOUT
+		 * would fail. */
+		if (aio_dev_queue_limit(&st, "discard_max_bytes") > 0) {
+			disk->unmap = aio_range_blkdiscard;
+		}
+		if (aio_dev_queue_limit(&st, "write_zeroes_max_bytes") > 0) {
+			disk->zero = aio_range_blkzeroout;
+		}
+		AIO_FDISK_NOTICELOG(disk, "trim (block device): unmap=%s, zero=%s\n",
+				    disk->unmap ? "BLKDISCARD" : "unsupported",
+				    disk->zero ? "BLKZEROOUT" : "unsupported");
 	} else {
-		spdk_bdev_io_complete_aio_status(spdk_bdev_io_from_ctx(aio_task), -errno);
+		disk->unmap = aio_range_fallocate_punch;
+		disk->zero = aio_range_fallocate_punch;
+		AIO_FDISK_NOTICELOG(disk, "trim enabled (file): unmap/zero=fallocate(PUNCH_HOLE)\n");
+	}
+}
+
+static void
+bdev_aio_range_offload(struct spdk_bdev_io *bdev_io, aio_range_fn fn)
+{
+	struct file_disk *fdisk = fdisk_from_bdev(bdev_io->bdev);
+	struct aio_offload_req *req;
+
+	req = calloc(1, sizeof(*req));
+	if (req == NULL) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+		return;
+	}
+
+	req->bdev_io = bdev_io;
+	req->orig_thread = spdk_get_thread();
+	req->fd = fdisk->fd;
+	req->fn = fn;
+	req->range[0] = bdev_io->u.bdev.offset_blocks * bdev_io->bdev->blocklen;
+	req->range[1] = bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen;
+
+	if (aio_offload_submit(req) < 0) {
+		free(req);
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
 	}
 }
 
 static void
 bdev_aio_unmap(struct spdk_bdev_io *bdev_io)
 {
-	int mode = FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE;
+	struct file_disk *fdisk = fdisk_from_bdev(bdev_io->bdev);
 
-	bdev_aio_fallocate(bdev_io, mode);
+	if (fdisk->unmap == NULL) {
+		spdk_bdev_io_complete_aio_status(bdev_io, -ENOTSUP);
+		return;
+	}
+
+	bdev_aio_range_offload(bdev_io, fdisk->unmap);
 }
-
 
 static void
 bdev_aio_write_zeros(struct spdk_bdev_io *bdev_io)
 {
-	int mode = FALLOC_FL_ZERO_RANGE;
+	struct file_disk *fdisk = fdisk_from_bdev(bdev_io->bdev);
 
-	bdev_aio_fallocate(bdev_io, mode);
+	if (fdisk->zero == NULL) {
+		spdk_bdev_io_complete_aio_status(bdev_io, -ENOTSUP);
+		return;
+	}
+
+	bdev_aio_range_offload(bdev_io, fdisk->zero);
 }
 #endif
 
@@ -772,8 +1075,10 @@ bdev_aio_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type)
 		return true;
 
 	case SPDK_BDEV_IO_TYPE_UNMAP:
+		return fdisk->unmap != NULL;
+
 	case SPDK_BDEV_IO_TYPE_WRITE_ZEROES:
-		return fdisk->fallocate;
+		return fdisk->zero != NULL;
 
 	default:
 		return false;
@@ -1031,6 +1336,10 @@ create_aio_bdev(const char *name, const char *filename, uint32_t block_size, boo
 		goto error_return;
 	}
 
+#ifndef __FreeBSD__
+	set_aio_range_functions(fdisk);
+#endif
+
 	disk_size = spdk_fd_get_size(fdisk->fd);
 
 	fdisk->disk.product_name = "AIO disk";
@@ -1212,12 +1521,23 @@ bdev_aio_initialize(void)
 	spdk_io_device_register(&aio_if, bdev_aio_group_create_cb, bdev_aio_group_destroy_cb,
 				sizeof(struct bdev_aio_group_channel), "aio_module");
 
+#ifndef __FreeBSD__
+	if (aio_offload_init() < 0) {
+		SPDK_ERRLOG("Failed to start the aio unmap/write-zeroes offload worker\n");
+		spdk_io_device_unregister(&aio_if, NULL);
+		return -1;
+	}
+#endif
+
 	return 0;
 }
 
 static void
 bdev_aio_fini(void)
 {
+#ifndef __FreeBSD__
+	aio_offload_fini();
+#endif
 	spdk_io_device_unregister(&aio_if, NULL);
 }
 

--- a/module/bdev/uring/bdev_uring.c
+++ b/module/bdev/uring/bdev_uring.c
@@ -21,6 +21,10 @@
 #include "spdk/log.h"
 #include "spdk_internal/uring.h"
 
+#include <linux/falloc.h>
+#include <linux/loop.h>
+#include <sys/sysmacros.h>
+
 #ifdef SPDK_CONFIG_URING_ZNS
 #include <linux/blkzoned.h>
 #define SECTOR_SHIFT 9
@@ -80,6 +84,12 @@ struct bdev_uring {
 	struct bdev_uring_zoned_dev	zd;
 	char			*filename;
 	int			fd;
+	/* Whether UNMAP / WRITE_ZEROES are advertised, and (for UNMAP) whether the
+	 * backing is a block device, so the syscall path can be chosen: files use
+	 * IORING_OP_FALLOCATE(PUNCH_HOLE), block devices use BLOCK_URING_CMD_DISCARD. */
+	bool			unmap;
+	bool			zero;
+	bool			is_blkdev;
 	TAILQ_ENTRY(bdev_uring)  link;
 
 	bool			hot_remove_in_progress;
@@ -89,6 +99,10 @@ static int bdev_uring_init(void);
 static void bdev_uring_fini(void);
 static void uring_free_bdev(struct bdev_uring *uring);
 static TAILQ_HEAD(, bdev_uring) g_uring_bdev_head = TAILQ_HEAD_INITIALIZER(g_uring_bdev_head);
+
+/* Kernel support for BLOCK_URING_CMD_DISCARD (Linux 6.12+): -1 unprobed, 0 no, 1 yes.
+ * Probed at most once, on the first block-device uring bdev, never in the I/O path. */
+static int g_uring_blk_discard = -1;
 
 #define SPDK_URING_QUEUE_DEPTH 512
 #define MAX_EVENTS_PER_POLL 32
@@ -285,6 +299,191 @@ bdev_uring_writev(struct bdev_uring *uring, struct spdk_io_channel *ch,
 
 	group_ch->io_pending++;
 	return nbytes;
+}
+
+/*
+ * Submit an async UNMAP or WRITE_ZEROES via IORING_OP_FALLOCATE on the existing
+ * ring. io_uring is natively async, so no worker thread is needed and the
+ * completion is reaped by bdev_uring_reap alongside reads and writes. fallocate
+ * completes with res == 0 on success, so len is recorded as 0 for the reaper.
+ */
+static int64_t
+bdev_uring_fallocate(struct bdev_uring *uring, struct spdk_io_channel *ch,
+		     struct spdk_bdev_io *bdev_io, int mode)
+{
+	struct bdev_uring_task *uring_task = (struct bdev_uring_task *)bdev_io->driver_ctx;
+	struct bdev_uring_io_channel *uring_ch = spdk_io_channel_get_ctx(ch);
+	struct bdev_uring_group_channel *group_ch = uring_ch->group_ch;
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(&group_ch->uring);
+	if (!sqe) {
+		URING_DEBUGLOG(uring, "get sqe failed as out of resource\n");
+		return -ENOMEM;
+	}
+
+	io_uring_prep_fallocate(sqe, uring->fd, mode,
+				bdev_io->u.bdev.offset_blocks * bdev_io->bdev->blocklen,
+				bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen);
+	io_uring_sqe_set_data(sqe, uring_task);
+	uring_task->len = 0;
+	uring_task->ch = uring_ch;
+
+	group_ch->io_pending++;
+	return 0;
+}
+
+/* Block-device UNMAP via BLOCK_URING_CMD_DISCARD (Linux 6.12+), reaped like the
+ * others. Completes with res == 0 on success, so len is recorded as 0. */
+static int64_t
+bdev_uring_cmd_discard(struct bdev_uring *uring, struct spdk_io_channel *ch,
+		       struct spdk_bdev_io *bdev_io)
+{
+	struct bdev_uring_task *uring_task = (struct bdev_uring_task *)bdev_io->driver_ctx;
+	struct bdev_uring_io_channel *uring_ch = spdk_io_channel_get_ctx(ch);
+	struct bdev_uring_group_channel *group_ch = uring_ch->group_ch;
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(&group_ch->uring);
+	if (!sqe) {
+		URING_DEBUGLOG(uring, "get sqe failed as out of resource\n");
+		return -ENOMEM;
+	}
+
+	io_uring_prep_cmd_discard(sqe, uring->fd,
+				  bdev_io->u.bdev.offset_blocks * bdev_io->bdev->blocklen,
+				  bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen);
+	io_uring_sqe_set_data(sqe, uring_task);
+	uring_task->len = 0;
+	uring_task->ch = uring_ch;
+
+	group_ch->io_pending++;
+	return 0;
+}
+
+/*
+ * Probe, at most once, whether this kernel supports BLOCK_URING_CMD_DISCARD
+ * (6.12+). Support is a property of the kernel, not of any particular device
+ * (every block device routes through the same blkdev_uring_cmd handler), so it
+ * is checked on a disposable loop device rather than by issuing a destructive
+ * discard on a real backing store. A zero-length discard cannot be used to
+ * probe: the kernel rejects len == 0 with -EINVAL on every version, so only a
+ * real, aligned discard returning 0 distinguishes a kernel that supports the
+ * command (e.g. stable 6.12) from one that rejects it (observed on a
+ * bleeding-edge io_uring development tree that reports a newer version). Cached
+ * globally, so it runs only on the first block-device uring bdev, never in the
+ * I/O path.
+ */
+static bool
+bdev_uring_blk_discard_supported(void)
+{
+	char backing[] = "/tmp/spdk_uring_discard_probe.XXXXXX";
+	char loopname[32];
+	struct io_uring ring;
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int lctl = -1, loopfd = -1, backfd = -1, devnr;
+	bool ring_ok = false;
+
+	if (g_uring_blk_discard >= 0) {
+		return g_uring_blk_discard;
+	}
+	g_uring_blk_discard = 0;
+
+	backfd = mkstemp(backing);
+	if (backfd < 0) {
+		SPDK_NOTICELOG("uring: discard probe: mkstemp failed (errno %d); "
+			       "block-device discard disabled\n", errno);
+		return false;
+	}
+	unlink(backing);				/* anonymous; freed on close */
+	if (ftruncate(backfd, 1 << 20) != 0) {		/* 1 MiB backing store */
+		goto out;
+	}
+
+	lctl = open("/dev/loop-control", O_RDWR | O_CLOEXEC);
+	if (lctl < 0) {
+		SPDK_NOTICELOG("uring: discard probe: /dev/loop-control unavailable "
+			       "(errno %d); block-device discard disabled\n", errno);
+		goto out;
+	}
+	devnr = ioctl(lctl, LOOP_CTL_GET_FREE);
+	if (devnr < 0) {
+		goto out;
+	}
+	snprintf(loopname, sizeof(loopname), "/dev/loop%d", devnr);
+	/* O_DIRECT is unsupported on some backing filesystems (e.g. tmpfs); the
+	 * discard transfers no data, so plain buffered access probes identically. */
+	loopfd = open(loopname, O_RDWR | O_CLOEXEC);
+	if (loopfd < 0 || ioctl(loopfd, LOOP_SET_FD, backfd) != 0) {
+		goto out;
+	}
+
+	if (io_uring_queue_init(1, &ring, 0) == 0) {
+		ring_ok = true;
+		sqe = io_uring_get_sqe(&ring);
+		if (sqe != NULL) {
+			/* real, aligned, single-block discard: the only submission a
+			 * working kernel completes with res == 0 */
+			io_uring_prep_cmd_discard(sqe, loopfd, 0, 512);
+			if (io_uring_submit(&ring) == 1 &&
+			    io_uring_wait_cqe(&ring, &cqe) == 0) {
+				g_uring_blk_discard = (cqe->res == 0) ? 1 : 0;
+				SPDK_NOTICELOG("uring: BLOCK_URING_CMD_DISCARD kernel probe "
+					       "res=%d; block-device discard %s\n", cqe->res,
+					       g_uring_blk_discard ? "enabled" : "disabled");
+				io_uring_cqe_seen(&ring, cqe);
+			}
+		}
+	}
+
+out:
+	if (ring_ok) {
+		io_uring_queue_exit(&ring);
+	}
+	if (loopfd >= 0) {
+		ioctl(loopfd, LOOP_CLR_FD, 0);
+		close(loopfd);
+	}
+	if (lctl >= 0) {
+		close(lctl);
+	}
+	if (backfd >= 0) {
+		close(backfd);
+	}
+	return g_uring_blk_discard;
+}
+
+/*
+ * Whether a specific block device advertises discard support, via
+ * queue/discard_max_bytes. Non-destructive; gates per-device so UNMAP is never
+ * advertised on a disk the kernel would reject with -EOPNOTSUPP.
+ */
+static bool
+bdev_uring_dev_supports_discard(int fd)
+{
+	struct stat st;
+	char path[64];
+	char buf[32];
+	int sfd;
+	ssize_t n;
+
+	if (fstat(fd, &st) != 0 || !S_ISBLK(st.st_mode)) {
+		return false;
+	}
+	snprintf(path, sizeof(path), "/sys/dev/block/%u:%u/queue/discard_max_bytes",
+		 major(st.st_rdev), minor(st.st_rdev));
+	sfd = open(path, O_RDONLY);
+	if (sfd < 0) {
+		return false;
+	}
+	n = read(sfd, buf, sizeof(buf) - 1);
+	close(sfd);
+	if (n <= 0) {
+		return false;
+	}
+	buf[n] = '\0';
+	return strtoull(buf, NULL, 10) > 0;
 }
 
 static int
@@ -702,6 +901,7 @@ bdev_uring_check_zoned_support(struct bdev_uring *uring, const char *name, const
 static int
 _bdev_uring_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
 {
+	struct bdev_uring *uring = uring_from_bdev(bdev_io->bdev);
 
 	switch (bdev_io->type) {
 	case SPDK_BDEV_IO_TYPE_GET_ZONE_INFO:
@@ -715,6 +915,21 @@ _bdev_uring_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev
 	case SPDK_BDEV_IO_TYPE_WRITE:
 		spdk_bdev_io_get_buf(bdev_io, bdev_uring_get_buf_cb,
 				     bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen);
+		return 0;
+	case SPDK_BDEV_IO_TYPE_UNMAP: {
+		int64_t rc = uring->is_blkdev ?
+			     bdev_uring_cmd_discard(uring, ch, bdev_io) :
+			     bdev_uring_fallocate(uring, ch, bdev_io,
+						  FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE);
+		if (rc == -ENOMEM) {
+			spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+		}
+		return 0;
+	}
+	case SPDK_BDEV_IO_TYPE_WRITE_ZEROES:
+		if (bdev_uring_fallocate(uring, ch, bdev_io, FALLOC_FL_ZERO_RANGE) == -ENOMEM) {
+			spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_NOMEM);
+		}
 		return 0;
 	default:
 		return -1;
@@ -740,6 +955,10 @@ bdev_uring_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type)
 	case SPDK_BDEV_IO_TYPE_READ:
 	case SPDK_BDEV_IO_TYPE_WRITE:
 		return true;
+	case SPDK_BDEV_IO_TYPE_UNMAP:
+		return ((struct bdev_uring *)ctx)->unmap;
+	case SPDK_BDEV_IO_TYPE_WRITE_ZEROES:
+		return ((struct bdev_uring *)ctx)->zero;
 	default:
 		return false;
 	}
@@ -860,6 +1079,7 @@ create_uring_bdev(const struct bdev_uring_opts *opts)
 	uint64_t bdev_size;
 	int rc;
 	uint32_t block_size = opts->block_size;
+	struct stat st;
 
 	uring = calloc(1, sizeof(*uring));
 	if (!uring) {
@@ -879,6 +1099,21 @@ create_uring_bdev(const struct bdev_uring_opts *opts)
 
 	if (bdev_uring_open(uring)) {
 		goto error_return;
+	}
+
+	/* Files: UNMAP/WRITE_ZEROES via fallocate (punch-hole / zero-range), always
+	 * available above the 5.13 uring floor. Block devices: UNMAP via
+	 * BLOCK_URING_CMD_DISCARD when the kernel supports it (probed once); there is
+	 * no io_uring write-zeroes op for block devices, so that stays file-only. */
+	if (fstat(uring->fd, &st) == 0) {
+		if (S_ISREG(st.st_mode)) {
+			uring->unmap = true;
+			uring->zero = true;
+		} else if (S_ISBLK(st.st_mode)) {
+			uring->is_blkdev = true;
+			uring->unmap = bdev_uring_blk_discard_supported() &&
+				       bdev_uring_dev_supports_discard(uring->fd);
+		}
 	}
 
 	bdev_size = spdk_fd_get_size(uring->fd);


### PR DESCRIPTION
Implements the async UNMAP passthrough half (Part 2) of the Mayastor trim/unmap
OEP (openebs/openebs#4074) for both bdev types a Mayastor pool can sit on. Two
commits, one per module; they touch disjoint files and can be split into
separate PRs if preferred.

## bdev/aio: offload UNMAP and WRITE_ZEROES to a worker thread

The stock aio bdev runs fallocate()/ioctl synchronously inline on the reactor
thread, blocking it for tens to hundreds of milliseconds on large ranges,
which is why trim was historically kept disabled. This offloads each range op
to a single worker thread pinned off the reactor cores, completing back on the
originating thread via spdk_thread_send_msg(). Block devices use
ioctl(BLKDISCARD) for UNMAP and ioctl(BLKZEROOUT) for WRITE_ZEROES; regular
files use fallocate(PUNCH_HOLE|KEEP_SIZE). Each op is advertised independently
and only where the device supports it (discard_max_bytes for UNMAP,
write_zeroes_max_bytes for WRITE_ZEROES), all behind the existing
fallocate=true opt-in. Revives the reverted #11.

## bdev/uring: add UNMAP and WRITE_ZEROES

io_uring is already asynchronous, so the ops are submitted on the existing
ring and reaped alongside reads and writes. Regular files use
IORING_OP_FALLOCATE; block devices use BLOCK_URING_CMD_DISCARD (Linux 6.12+).
Kernel support for the block command cannot be derived from the version
(distros backport it; development trees can reject it) nor from the opcode
probe (it cannot see cmd_ops), so it is detected at runtime by a one-time real
discard on a disposable loop device, plus a per-device discard_max_bytes gate.

## Validation

End-to-end on stock Mayastor backends (LVS pool on a loop device, pool disk
aio://<loop>?fallocate=true, ENABLE_BS_CLUSTER_UNMAP=true, thin replica ->
nexus -> NVMe-oF -> host):

- Host advertises discard (lsblk -D nonzero, ONCS DSM set).
- fstrim after deleting 2 GiB: replica allocated bytes 2.3 GB -> 151 MB
  (blobstore cluster release), loop backing file 2.28 GB -> 128 MB (device
  reclaim through BLKDISCARD).
- No reactor stall: 4k randread 13,765 IOPS / p99 0.13 ms / max 5.3 ms
  baseline vs 12,758 IOPS / p99 0.17 ms / max 7.1 ms under a continuous
  256 MiB-discard storm.
- io-engine integration suite (aio_fallocate) passes: advertisement,
  parameter validation, unmap data path with file-space assertions, nexus
  AND advertisement semantics.
- uring block command: validated on stock 6.12 in QEMU (loop and virtio-blk,
  with and without O_DIRECT); the runtime probe correctly disables the path
  on a kernel whose in-flight io_uring rework rejects the command,
  confirming probing over version checks.

Refs: openebs/openebs#4074
